### PR TITLE
Add a themed SVG favicon

### DIFF
--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Bridge Assault favicon</title>
+  <desc id="desc">A stylized bridge badge with a targeting reticle and warm arcade lighting.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f3f73"/>
+      <stop offset="60%" stop-color="#0e1730"/>
+      <stop offset="100%" stop-color="#080b15"/>
+    </linearGradient>
+    <linearGradient id="bridge" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffd978"/>
+      <stop offset="100%" stop-color="#d9871f"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="35%" r="65%">
+      <stop offset="0%" stop-color="#8ec5ff" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#8ec5ff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="64" height="64" rx="16" fill="url(#bg)"/>
+  <circle cx="32" cy="24" r="22" fill="url(#glow)"/>
+
+  <circle cx="32" cy="32" r="18" fill="none" stroke="#7fc1ff" stroke-opacity="0.75" stroke-width="2"/>
+  <path d="M32 10v8M32 46v8M10 32h8M46 32h8" stroke="#b7dcff" stroke-width="2.4" stroke-linecap="round"/>
+  <circle cx="32" cy="32" r="3.2" fill="#f5fbff"/>
+
+  <path d="M14 44h36" stroke="#f6c45f" stroke-width="3" stroke-linecap="round"/>
+  <path d="M18 44l6-18M46 44l-6-18" stroke="url(#bridge)" stroke-width="4.2" stroke-linecap="round"/>
+  <path d="M24 26h16" stroke="url(#bridge)" stroke-width="4.2" stroke-linecap="round"/>
+  <path d="M24 26l-6 18M40 26l6 18" stroke="#ffebac" stroke-opacity="0.55" stroke-width="1.6" stroke-linecap="round"/>
+
+  <path d="M45 18l7-5-2 8" fill="#ff9a3d"/>
+  <path d="M47 16l-5 5" stroke="#ffe4a3" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
+<link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
 <link rel="stylesheet" href="style.css?v=12">
 <style>
 /* p5.js canvas sits behind all overlays.


### PR DESCRIPTION
## Summary
- add a lightweight SVG favicon that matches the game's bridge-and-assault theme
- wire the favicon into the site head for browser tab support

## Testing
- not run (asset + HTML head update only)

Closes #24

Replacement for closed PR #25 after branch rename.
