### PR TITLE
Add animated monster sprite decorations to main menu

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -56,6 +56,11 @@ body > canvas {
 <div id="weaponSlots" style="display:none"></div>
 
 <div id="overlay">
+    <!-- Decorative animated monster sprites (pure CSS, no interaction) -->
+    <div class="menu-monster monster-dragon-left" aria-hidden="true"></div>
+    <div class="menu-monster monster-capybara-right" aria-hidden="true"></div>
+    <div class="menu-monster monster-boss-top" aria-hidden="true"></div>
+
     <h1>BRIDGE ASSAULT</h1>
     <h2 data-i18n="menu.subtitle">桥 梁 突 击</h2>
     <div id="coinDisplay">

--- a/docs/style.css
+++ b/docs/style.css
@@ -1881,3 +1881,101 @@ body::after {
     padding: min(10px, 2vw) min(28px, 6vw) !important;
     font-size: min(15px, 3.2vw) !important;
 }
+
+/* ============================================================
+   MENU MONSTER DECORATIONS — animated sprite sheet creatures
+   Pure CSS: background-image + steps() keyframe animation
+   ============================================================ */
+.menu-monster {
+    position: absolute;
+    pointer-events: none;
+    z-index: 0 !important;
+    image-rendering: pixelated;
+    image-rendering: crisp-edges;
+    filter: drop-shadow(0 0 18px rgba(0, 0, 0, 0.6));
+}
+
+/* --- Small Dragon (left side) ---
+   Sprite: 2688×128, 21 frames, each 128×128
+   Display: 96×96, float up/down */
+.monster-dragon-left {
+    width: 96px;
+    height: 96px;
+    left: 4%;
+    bottom: 14%;
+    opacity: 0.58;
+    background: url('assets/small_dragon.png') 0 0 / 2016px 96px no-repeat;
+    animation:
+        sprite-dragon 1.8s steps(21) infinite,
+        float-y 3.2s ease-in-out infinite alternate;
+}
+@keyframes sprite-dragon {
+    to { background-position: -2016px 0; }
+}
+
+/* --- Capybara (right side) ---
+   Sprite: 2048×128, 16 frames, each 128×128
+   Display: 88×88, float opposite phase */
+.monster-capybara-right {
+    width: 88px;
+    height: 88px;
+    right: 4%;
+    bottom: 15%;
+    transform: scaleX(-1);
+    opacity: 0.45;
+    background: url('assets/capybara.png') 0 0 / 1408px 88px no-repeat;
+    animation:
+        sprite-capybara 1.4s steps(16) infinite,
+        float-y 2.8s ease-in-out infinite alternate-reverse;
+}
+@keyframes sprite-capybara {
+    to { background-position: -1408px 0; }
+}
+
+/* --- Boss Dragon (top, near title) ---
+   Sprite: 256×64, 4 frames, each 64×64
+   Display: 112×112 (scaled up), subtle pulse glow */
+.monster-boss-top {
+    width: 112px;
+    height: 112px;
+    left: 50%;
+    top: 10%;
+    transform: translateX(calc(-50% + 220px));
+    opacity: 0.35;
+    background: url('assets/boss_dragon.png') 0 0 / 448px 112px no-repeat;
+    animation:
+        sprite-boss 1.0s steps(4) infinite,
+        float-y 4s ease-in-out infinite alternate,
+        pulse-glow 3s ease-in-out infinite alternate;
+}
+@keyframes sprite-boss {
+    to { background-position: -448px 0; }
+}
+
+/* Shared floating animation */
+@keyframes float-y {
+    from { margin-top: -10px; }
+    to   { margin-top: 10px; }
+}
+
+/* Boss glow pulse */
+@keyframes pulse-glow {
+    from { filter: drop-shadow(0 0 16px rgba(255, 80, 40, 0.3))
+                   drop-shadow(0 0 40px rgba(200, 60, 30, 0.15)); }
+    to   { filter: drop-shadow(0 0 24px rgba(255, 100, 50, 0.5))
+                   drop-shadow(0 0 60px rgba(200, 60, 30, 0.25)); }
+}
+
+/* Mobile: hide decorations to keep menu clean */
+@media (max-width: 768px), (max-aspect-ratio: 1/1) {
+    .menu-monster { display: none; }
+}
+/* Small desktop: shrink and fade further */
+@media (max-width: 1100px) and (min-width: 769px) {
+    .monster-dragon-left  { width: 64px; height: 64px; background-size: 1344px 64px; opacity: 0.35; }
+    .monster-capybara-right { width: 60px; height: 60px; background-size: 960px 60px; opacity: 0.32; }
+    .monster-boss-top { width: 80px; height: 80px; background-size: 320px 80px; opacity: 0.30; }
+    @keyframes sprite-dragon   { to { background-position: -1344px 0; } }
+    @keyframes sprite-capybara { to { background-position: -960px 0; } }
+    @keyframes sprite-boss     { to { background-position: -320px 0; } }
+}


### PR DESCRIPTION
## Summary
- Add three CSS-animated monster sprites as decorations to the main menu overlay
- Small Dragon (bottom-left), Capybara (bottom-right), Boss Dragon (top-right)
- Pure CSS implementation using `background-image` sprite sheets + `steps()` keyframes
- No JavaScript changes required

## Details
- Uses existing sprite assets (`small_dragon.png`, `capybara.png`, `boss_dragon.png`)
- Floating `@keyframes` animation for gentle up/down motion
- Boss Dragon has additional glow pulse effect
- `pointer-events: none` — zero interference with buttons
- Responsive: hidden on mobile (`max-width: 768px`), reduced on small desktop
- Semi-transparent to blend with the atmospheric background

## Files Changed
- `docs/index.html` — 3 decorative `<div>` elements inside `#overlay`
- `docs/style.css` — sprite animation keyframes + positioning + responsive rules

## Test Plan
- [ ] Desktop: all 3 monsters visible and animating on main menu
- [ ] Buttons remain fully clickable (not blocked by decorations)
- [ ] Mobile viewport: decorations hidden
- [ ] Small desktop (769-1100px): decorations shrunk and faded

Closes #32