### PR TITLE
Fix leaderboard sync to include Level 2 high scoresFix leaderboard sync to include Level 2 high scores, Closes #34

### DIFF
--- a/docs/js/leaderboard.js
+++ b/docs/js/leaderboard.js
@@ -49,6 +49,18 @@ async function fetchLeaderboard(limit = 5) {
     return await resp.json();
 }
 
+function _getLeaderboardBestScore() {
+    const defaultHs = getHighScore();
+    const level2Hs = (playerData && playerData.l2HighScore) || { score: 0, wave: 0 };
+    if (
+        level2Hs.score > defaultHs.score ||
+        (level2Hs.score === defaultHs.score && level2Hs.wave > defaultHs.wave)
+    ) {
+        return { score: level2Hs.score, wave: level2Hs.wave, level: 2 };
+    }
+    return { score: defaultHs.score, wave: defaultHs.wave, level: 1 };
+}
+
 // Count non-hidden players with score strictly higher than myScore → rank = count + 1
 async function _fetchMyRank(myScore) {
     const filter = encodeURIComponent(`hidden=false&&score>${Math.floor(myScore)}`);
@@ -62,9 +74,9 @@ async function _fetchMyRank(myScore) {
 async function syncHighScore() {
     const player = getLbPlayer();
     if (!player || player.hidden) return; // skip if player hid themselves
-    const hs = getHighScore();
+    const hs = _getLeaderboardBestScore();
     if (hs.score <= 0) return;
-    const lv = playerData ? Math.floor(playerData.level || 1) : 1;
+    const lv = hs.level || (playerData ? Math.floor(playerData.level || 1) : 1);
     try {
         await _patchRecord(player.recordId, { score: Math.floor(hs.score), wave: Math.floor(hs.wave), level: lv });
     } catch {
@@ -95,7 +107,7 @@ async function toggleLbVisibility() {
             if (newHidden) {
                 if (rankSpan) { rankSpan.textContent = '--'; rankSpan.style.color = '#888'; }
             } else {
-                const hs = getHighScore();
+                const hs = _getLeaderboardBestScore();
                 if (hs.score > 0 && rankSpan) {
                     const myRank = await _fetchMyRank(hs.score);
                     if (myRank !== null) {
@@ -225,8 +237,8 @@ async function _renderList(myName) {
         if (myName && player) {
             html += `<div class="lb-my-rank-sep"></div>`;
             if (player.hidden) {
-                const lv = playerData ? Math.floor(playerData.level || 1) : 1;
-                const hs = getHighScore();
+                const hs = _getLeaderboardBestScore();
+                const lv = hs.level || (playerData ? Math.floor(playerData.level || 1) : 1);
                 html += `<div class="lb-row lb-mine">
                     <span class="lb-rank" style="color:#888">--</span>
                     <span class="lb-name">${_lbEscape(myName)}</span>
@@ -235,10 +247,10 @@ async function _renderList(myName) {
                     <span class="lb-wave">${hs.wave > 0 ? 'W'+hs.wave : '--'}</span>
                 </div>`;
             } else {
-                const hs = getHighScore();
+                const hs = _getLeaderboardBestScore();
                 if (hs.score > 0) {
                     const myRank = await _fetchMyRank(hs.score);
-                    const lv = playerData ? Math.floor(playerData.level || 1) : 1;
+                    const lv = hs.level || (playerData ? Math.floor(playerData.level || 1) : 1);
                     if (myRank !== null) {
                         const myMedal = myRank === 1 ? '🥇' : myRank === 2 ? '🥈' : myRank === 3 ? '🥉' : `${myRank}`;
                         html += `<div class="lb-row lb-mine">


### PR DESCRIPTION
## Summary

This PR fixes Issue #34 by making leaderboard sync use the best available local score source across both the default high score and `playerData.l2HighScore`.

Previously, Level 2 personal bests could be stored locally but never correctly synced to the online leaderboard, because sync logic only read the default high score source.

Closes #34

## What Changed

- added a helper to choose the best leaderboard score source
- updated leaderboard sync to use that source
- updated the local “my row” leaderboard display to stay consistent with the synced score source

## Files Changed

- `docs/js/leaderboard.js`

## Testing

Manual verification target:

1. Join the leaderboard.
2. Achieve a new high score in Level 2.
3. Finish the run and trigger game over.
4. Reopen the leaderboard.
5. Confirm the synced record now reflects the best local score source instead of only the default Level 1 high score.
