### PR TITLE
Fix pause menu Level 2 high score savingFix pause menu Level 2 high score saving, Closes #36

### DIFF
--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -36,12 +36,13 @@ function menuFromPause() {
     stopBGM();
     if (game) {
         if (game.isTutorial) restoreTutorialWeaponCharges();
+        const currentLvl = game.currentLevel || 1;
         playerData.level = game.level;
         playerData.exp = game.exp;
         flushPlayerDataSave(true);
         savePlayerData(playerData);
         if (!game.isTutorial) {
-            saveHighScore(game.score, game.wave);
+            saveLevelAwareHighScore(currentLvl, game.score, game.wave);
             syncHighScore();
         }
     }
@@ -520,6 +521,19 @@ function isBetterRunRecord(score, wave, prev) {
     return score > prevScore || (score === prevScore && wave > prevWave);
 }
 
+function saveLevelAwareHighScore(level, score, wave) {
+    if ((level || 1) === 2) {
+        const prev = playerData.l2HighScore || { score: 0, wave: 0 };
+        if (isBetterRunRecord(score, wave, prev)) {
+            playerData.l2HighScore = { score, wave };
+            savePlayerData(playerData);
+            return true;
+        }
+        return false;
+    }
+    return saveHighScore(score, wave);
+}
+
 // ============================================================
 // REVIVE SYSTEM
 // ============================================================
@@ -612,17 +626,7 @@ function showGameOver() {
     savePlayerData(playerData);
     updateEndOfGameStats();
     const currentLvl = game.currentLevel || 1;
-    let isNewRecord;
-    if (currentLvl === 2) {
-        const prev = playerData.l2HighScore || { score: 0, wave: 0 };
-        if (isBetterRunRecord(game.score, game.wave, prev)) {
-            playerData.l2HighScore = { score: game.score, wave: game.wave };
-            savePlayerData(playerData);
-            isNewRecord = true;
-        } else { isNewRecord = false; }
-    } else {
-        isNewRecord = saveHighScore(game.score, game.wave);
-    }
+    const isNewRecord = saveLevelAwareHighScore(currentLvl, game.score, game.wave);
     syncHighScore();
     const hs = currentLvl === 2
         ? (playerData.l2HighScore || { score: 0, wave: 0 })


### PR DESCRIPTION
## Summary

This PR fixes Issue #36 by making the pause-menu exit flow use the same level-aware high score logic as the normal game-over flow.

Previously, leaving Level 2 through the pause menu always saved through the default high score slot, which could bypass `playerData.l2HighScore` and store the score in the wrong place.

Closes #36

## What Changed

- added a shared helper for level-aware high score saving
- updated `menuFromPause()` to use the correct Level 2 high score slot
- updated `showGameOver()` to reuse the same logic for consistency

## Files Changed

- `docs/js/ui.js`

## Testing

Manual verification target:

1. Start a Level 2 run.
2. Achieve a score higher than the current Level 2 local best.
3. Pause the game and return to the main menu.
4. Reopen Level Select.
5. Confirm the Level 2 best score is updated in the correct slot.
