### PR TITLE
Fix menu monster decorations collapsing into flex column

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
 <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="stylesheet" href="style.css?v=12">
+<link rel="stylesheet" href="style.css?v=13">
 <style>
 /* p5.js canvas sits behind all overlays.
    Use "body > canvas" to target only the p5 canvas (direct child of body),

--- a/docs/style.css
+++ b/docs/style.css
@@ -1887,7 +1887,11 @@ body::after {
    Pure CSS: background-image + steps() keyframe animation
    ============================================================ */
 .menu-monster {
-    position: absolute;
+    /* !important required: `#overlay > *` (higher specificity) forces
+       position:relative + z-index:1 on every direct child. Without
+       overriding both, decorations collapse into the flex column at
+       the top of the overlay. */
+    position: absolute !important;
     pointer-events: none;
     z-index: 0 !important;
     image-rendering: pixelated;


### PR DESCRIPTION
## Problem

After merging #33, the three menu monster decorations did not appear at their designed positions (bottom-left, bottom-right, top-right). Instead, all three collapsed into the flex column at the top of the overlay, stacked on top of each other above the title.

![broken state](https://github.com/UoB-COMSM0166/2026-group-25/pull/33)

## Root cause

The CSS rule
\`\`\`css
#overlay > * {
    position: relative;
    z-index: 1;
}
\`\`\`
has higher specificity (`0,1,0,1`) than `.menu-monster` (`0,0,1,0`). It forced `position: relative` on every decoration div, removing them from absolute positioning and dropping them into \`#overlay\`'s flex-column layout.

#33 already added \`!important\` to \`z-index\` to work around this same rule, but \`position: absolute\` was missed.

## Fix

- Add \`!important\` to \`position: absolute\` in \`.menu-monster\`
- Add a comment explaining why both \`!important\` declarations are necessary
- Bump \`style.css?v=12\` → \`style.css?v=13\` so returning users bypass the cached broken CSS

## Verification

Before: all 3 sprites stacked above the title.
After: dragon at bottom-left, capybara at bottom-right, boss at top-right — matches #33's original design.