### PR TITLE
Fix game runtime edge cases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.css text working-tree-encoding=UTF-8
+*.html text working-tree-encoding=UTF-8
+*.js text working-tree-encoding=UTF-8
+*.md text working-tree-encoding=UTF-8

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,6 +29,18 @@ body > canvas {
 })();
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.0/p5.min.js"></script>
+<script>
+window.addEventListener('load', function() {
+    if (!window.p5) {
+        var el = document.getElementById('assetError');
+        var listEl = document.getElementById('assetErrorList');
+        if (listEl) {
+            listEl.innerHTML = '<li>p5.js failed to load from the CDN. Please check the network connection and reload.</li>';
+        }
+        if (el) el.classList.remove('hidden');
+    }
+});
+</script>
 </head>
 <body>
 
@@ -213,6 +225,16 @@ body > canvas {
             请使用电脑浏览器打开游戏
         </p>
         <div id="mobileBlockUrl">www.lzqqq.org/game</div>
+    </div>
+</div>
+
+<!-- Critical asset/dependency error overlay -->
+<div id="assetError" class="hidden">
+    <div id="assetErrorPanel">
+        <h2>Game assets failed to load</h2>
+        <p>The game can not start correctly until these files are available:</p>
+        <ul id="assetErrorList"></ul>
+        <button class="btn" onclick="location.reload()">Reload</button>
     </div>
 </div>
 

--- a/docs/js/audio.js
+++ b/docs/js/audio.js
@@ -4,14 +4,19 @@
 
 // Audio buffer cache: type → AudioBuffer
 const _audioBuffers = {};
+const _audioUnavailable = new Set();
+const _bgmUnavailable = new Set();
 let _audioLoaded = false;
 let _audioVolume = 0.5;
+let _audioDisabled = false;
+let _audioPreloadPromise = null;
 
 // BGM state
 let _bgmSource = null;
 let _bgmGain = null;
 let _bgmBuffers = {};  // level → AudioBuffer
 let _bgmPlaying = false;
+let _pendingBgmLevel = null;
 const BGM_FILES = {
     1: 'assets/audio/bgm.mp3',
     2: 'assets/audio/bgm_l2.mp3',
@@ -33,16 +38,28 @@ const SOUND_DEFS = {
 };
 
 function initAudio() {
-    if (!audioCtx) {
-        audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    const AudioCtor = window.AudioContext || window.webkitAudioContext;
+    if (!AudioCtor) {
+        _audioDisabled = true;
+        console.warn('Audio: Web Audio API is unavailable; continuing silently.');
+        return;
     }
-    // Resume suspended context (browser requires user gesture)
-    if (audioCtx.state === 'suspended') {
-        audioCtx.resume();
+    try {
+        if (!audioCtx) {
+            audioCtx = new AudioCtor();
+        }
+        // Resume suspended context (browser requires user gesture)
+        if (audioCtx.state === 'suspended') {
+            audioCtx.resume().catch(() => {});
+        }
+    } catch (err) {
+        _audioDisabled = true;
+        console.warn('Audio: failed to initialize; continuing silently.', err);
+        return;
     }
     if (!_audioLoaded) {
         _audioLoaded = true;
-        _preloadAudioBuffers();
+        _audioPreloadPromise = _preloadAudioBuffers();
     }
 }
 
@@ -56,6 +73,7 @@ async function _preloadAudioBuffers() {
             if (!resp.ok) throw new Error(`${resp.status} ${def.file}`);
             const buf = await resp.arrayBuffer();
             _audioBuffers[type] = await audioCtx.decodeAudioData(buf);
+            _audioUnavailable.delete(type);
         })
     );
     const loaded = results.filter(r => r.status === 'fulfilled').length;
@@ -63,6 +81,11 @@ async function _preloadAudioBuffers() {
     console.log(`Audio: ${loaded}/${entries.length} sounds loaded`);
     if (failed.length > 0) {
         console.warn('Audio: failed to load:', failed.map(r => r.reason.message));
+        results.forEach((result, idx) => {
+            if (result.status !== 'rejected') return;
+            const type = entries[idx] && entries[idx][0];
+            if (type) _audioUnavailable.add(type);
+        });
     }
 
     // Preload BGM for all levels
@@ -71,10 +94,20 @@ async function _preloadAudioBuffers() {
             const bgmResp = await fetch(file + '?v=' + _AUDIO_VERSION);
             if (bgmResp.ok) {
                 _bgmBuffers[lvl] = await audioCtx.decodeAudioData(await bgmResp.arrayBuffer());
+            } else {
+                _bgmUnavailable.add(String(lvl));
             }
-        } catch (_) {}
+        } catch (_) {
+            _bgmUnavailable.add(String(lvl));
+        }
     }
     console.log(`Audio: BGM loaded for ${Object.keys(_bgmBuffers).length} level(s)`);
+    _audioPreloadPromise = null;
+    if (_pendingBgmLevel && !_bgmPlaying) {
+        const pending = _pendingBgmLevel;
+        _pendingBgmLevel = null;
+        playBGM(pending);
+    }
 }
 
 // ============================================================
@@ -82,9 +115,21 @@ async function _preloadAudioBuffers() {
 // ============================================================
 function playBGM(level) {
     stopBGM();
+    if (_audioDisabled) return;
     const buf = _bgmBuffers[level || 1];
-    if (!audioCtx || !buf) return;
-    if (audioCtx.state === 'suspended') audioCtx.resume();
+    if (!audioCtx || !buf) {
+        if (_audioPreloadPromise) {
+            _pendingBgmLevel = level || 1;
+            return;
+        }
+        const key = String(level || 1);
+        if (!_bgmUnavailable.has(key)) {
+            _bgmUnavailable.add(key);
+            console.warn(`Audio: BGM for level ${key} is unavailable; continuing without music.`);
+        }
+        return;
+    }
+    if (audioCtx.state === 'suspended') audioCtx.resume().catch(() => {});
     _bgmGain = audioCtx.createGain();
     _bgmGain.gain.value = BGM_VOLUME;
     _bgmGain.connect(audioCtx.destination);
@@ -98,6 +143,7 @@ function playBGM(level) {
 }
 
 function stopBGM() {
+    _pendingBgmLevel = null;
     if (_bgmSource && _bgmPlaying) {
         try { _bgmSource.stop(); } catch (_) {}
         _bgmSource = null;
@@ -110,9 +156,9 @@ function setBGMVolume(vol) {
 }
 
 function playSound(type) {
-    if (!audioCtx) return;
+    if (_audioDisabled || !audioCtx) return;
     // Ensure context is running (user gesture may have happened since init)
-    if (audioCtx.state === 'suspended') audioCtx.resume();
+    if (audioCtx.state === 'suspended') audioCtx.resume().catch(() => {});
 
     // Try real audio buffer first
     const buffer = _audioBuffers[type];

--- a/docs/js/core.js
+++ b/docs/js/core.js
@@ -71,6 +71,7 @@ function createGame() {
         exp: playerData.exp || 0,
         currentLevel: 1,
         levelCompleted: false,
+        finalWaveSpawned: false,
         fireRateDebuff: 0,
     };
 }

--- a/docs/js/crypto.js
+++ b/docs/js/crypto.js
@@ -99,16 +99,8 @@ _s1=function(sk){
 // Global aliases — use non-obvious names
 _0x={s:_s0,l:_s1};
 
-// Runtime anti-debug: detect console open via timing
-// (lightweight — doesn't block, just adds friction)
-_p.push(setInterval(function(){
-    var t0=performance.now();
-    debugger;  // pauses only when DevTools is open
-    if(performance.now()-t0>100){
-        // DevTools detected — corrupt cached key (recovers on reload without DevTools)
-        _kf=_h(Math.random().toString());
-    }
-},5000));
+// Keep save validation deterministic so browser DevTools and automated tests
+// can inspect the game without being interrupted by runtime debugger traps.
 }();
 
 function _signedSave(k,d){_0x.s(k,d)}

--- a/docs/js/globals.js
+++ b/docs/js/globals.js
@@ -49,16 +49,24 @@ const startBtn = document.getElementById('startBtn');
 // PERSISTENT DATA (localStorage)
 // ============================================================
 
-const DATA_VERSION = 'v2';
+const DATA_VERSION = 'v3';
 (function checkDataVersion() {
     const stored = localStorage.getItem('bridgeAssault_dataVersion');
     if (stored !== DATA_VERSION) {
-        Object.keys(localStorage)
-            .filter(k => k.startsWith('bridgeAssault_'))
-            .forEach(k => localStorage.removeItem(k));
+        // Preserve existing player progress across schema bumps. Field-level
+        // migrations below fill missing values without deleting the whole save.
         localStorage.setItem('bridgeAssault_dataVersion', DATA_VERSION);
     }
 })();
+
+function resetBridgeAssaultSave() {
+    Object.keys(localStorage)
+        .filter(k => k.startsWith('bridgeAssault_'))
+        .forEach(k => localStorage.removeItem(k));
+    localStorage.setItem('bridgeAssault_dataVersion', DATA_VERSION);
+}
+
+window.resetBridgeAssaultSave = resetBridgeAssaultSave;
 
 function loadPlayerData() {
     try {
@@ -120,3 +128,65 @@ if (!playerData.stats) playerData.stats = {};
 if (!playerData.achievements) playerData.achievements = {};
 if (!playerData.achievementsClaimed) playerData.achievementsClaimed = {};
 savePlayerData(playerData);
+
+const assetLoadErrors = [];
+
+function recordAssetLoadError(label, path) {
+    assetLoadErrors.push({ label, path });
+    console.warn(`Asset failed to load: ${label} (${path})`);
+}
+
+function showAssetErrorOverlay() {
+    if (!assetLoadErrors.length) return;
+    const el = document.getElementById('assetError');
+    const listEl = document.getElementById('assetErrorList');
+    if (!el || !listEl) return;
+    listEl.innerHTML = assetLoadErrors
+        .map(err => `<li>${err.label}: <code>${err.path}</code></li>`)
+        .join('');
+    el.classList.remove('hidden');
+}
+
+function getMaxWavesForLevel(level) {
+    return Number(level) === 2 ? MAX_WAVES_LEVEL2 : MAX_WAVES_LEVEL1;
+}
+
+function isFinalWave(g) {
+    return !!g && g.wave >= getMaxWavesForLevel(g.currentLevel);
+}
+
+function hasAliveBoss(g) {
+    return !!g && g.enemies.some(e => e.alive && e.isBoss);
+}
+
+function shouldCompleteLevel(g) {
+    return !!g && !g.levelCompleted && g.finalWaveSpawned && isFinalWave(g) && !hasAliveBoss(g);
+}
+
+function collectRemainingRunCurrency(g) {
+    if (!g) return;
+    g.coins.forEach(coin => {
+        if (coin.collected) return;
+        coin.collected = true;
+        g.coinsCollected += coin.value;
+        playerData.coins += coin.value;
+        addStat('totalCoinsEarned', coin.value);
+    });
+    g.gems.forEach(gem => {
+        if (gem.collected) return;
+        gem.collected = true;
+        g.gemsCollected += gem.value;
+        playerData.gems = (playerData.gems || 0) + gem.value;
+        addStat('totalGemsEarned', gem.value);
+    });
+    markPlayerDataDirty();
+    flushPlayerDataSave(true);
+}
+
+function completeLevelOnce(g) {
+    if (!shouldCompleteLevel(g)) return false;
+    g.levelCompleted = true;
+    collectRemainingRunCurrency(g);
+    triggerLevelComplete();
+    return true;
+}

--- a/docs/js/helpers.js
+++ b/docs/js/helpers.js
@@ -43,7 +43,7 @@ function handleBossDeath(g, enemy) {
     const otherBossAlive = g.enemies.some(o => o !== enemy && o.alive && o.isBoss);
     if (!otherBossAlive) {
         g.enemyBullets = [];
-        if (enemy.isMegaBoss) g.midShopTimer = 90;
+        if (enemy.isMegaBoss && !isFinalWave(g)) g.midShopTimer = 90;
         // Track boss wave with zero troop loss
         if (g.preBossSquad && g.squadCount >= g.preBossSquad) {
             addStat('bossZeroLossWaves', 1);

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -6,16 +6,36 @@
 let _p5PatrickImg, _p5XiaoNaiLongImg, _p5BossImg, _p5FireEnemyImg;
 let _p5CapybaraImg, _p5PigEngineerImg, _p5CowGunImg, _p5CowCryImg, _p5ElephantImg;
 
+const CRITICAL_IMAGE_ASSETS = [
+    ['Patrick enemy sprite', 'assets/patrick.png'],
+    ['Small dragon sprite', 'assets/small_dragon.png'],
+    ['Boss dragon sprite', 'assets/boss_dragon.png'],
+    ['Fire enemy sprite', 'assets/fire_enemy.png'],
+    ['Capybara sprite', 'assets/capybara.png'],
+    ['Pig engineer sprite', 'assets/pig_engineer.png'],
+    ['Cow gun sprite', 'assets/cow_gun.png'],
+    ['Crying cow sprite', 'assets/cow_cry.png'],
+    ['Elephant sprite', 'assets/elephant.png'],
+];
+
+function loadCriticalImage(label, path) {
+    return loadImage(
+        path,
+        () => {},
+        () => recordAssetLoadError(label, path)
+    );
+}
+
 function preload() {
-    _p5PatrickImg      = loadImage('assets/patrick.png');
-    _p5XiaoNaiLongImg  = loadImage('assets/small_dragon.png');
-    _p5BossImg         = loadImage('assets/boss_dragon.png');
-    _p5FireEnemyImg    = loadImage('assets/fire_enemy.png');
-    _p5CapybaraImg     = loadImage('assets/capybara.png');
-    _p5PigEngineerImg  = loadImage('assets/pig_engineer.png');
-    _p5CowGunImg       = loadImage('assets/cow_gun.png');
-    _p5CowCryImg       = loadImage('assets/cow_cry.png');
-    _p5ElephantImg     = loadImage('assets/elephant.png');
+    _p5PatrickImg      = loadCriticalImage(...CRITICAL_IMAGE_ASSETS[0]);
+    _p5XiaoNaiLongImg  = loadCriticalImage(...CRITICAL_IMAGE_ASSETS[1]);
+    _p5BossImg         = loadCriticalImage(...CRITICAL_IMAGE_ASSETS[2]);
+    _p5FireEnemyImg    = loadCriticalImage(...CRITICAL_IMAGE_ASSETS[3]);
+    _p5CapybaraImg     = loadCriticalImage(...CRITICAL_IMAGE_ASSETS[4]);
+    _p5PigEngineerImg  = loadCriticalImage(...CRITICAL_IMAGE_ASSETS[5]);
+    _p5CowGunImg       = loadCriticalImage(...CRITICAL_IMAGE_ASSETS[6]);
+    _p5CowCryImg       = loadCriticalImage(...CRITICAL_IMAGE_ASSETS[7]);
+    _p5ElephantImg     = loadCriticalImage(...CRITICAL_IMAGE_ASSETS[8]);
 }
 
 function setup() {
@@ -37,6 +57,7 @@ function setup() {
     rawElephantImg     = document.getElementById('spriteElephant');
 
     _buildSpriteFrames();
+    showAssetErrorOverlay();
     initAudio();
     setupInput();
 
@@ -99,7 +120,7 @@ function draw() {
     screenW = width;
     screenH = height;
 
-    if (game && (game.state === 'playing' || game.state === 'paused' || game.state === 'revive')) {
+    if (game && game.state === 'playing') {
         update(deltaTime);
     }
     render();

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -169,7 +169,9 @@ function startGameWithLevel(level) {
 function triggerLevelComplete() {
     stopBGM();
     const g = game;
+    if (!g || g._levelCompleteTriggered) return;
     g.levelCompleted = true;
+    g._levelCompleteTriggered = true;
     updateEndOfGameStats();
     if (!playerData.unlockedLevels) playerData.unlockedLevels = [1];
     if (!playerData.unlockedLevels.includes(2)) {
@@ -177,7 +179,7 @@ function triggerLevelComplete() {
         savePlayerData(playerData);
     }
     const isL2Clear = g.currentLevel === 2;
-    const maxWaves = isL2Clear ? MAX_WAVES_LEVEL2 : MAX_WAVES_LEVEL1;
+    const maxWaves = getMaxWavesForLevel(g.currentLevel);
     const levelTag = isL2Clear ? 'LEVEL II' : 'LEVEL I';
     const unlockLine = isL2Clear ? '' : `<div style="color:#cc44ff;font-size:min(20px,4vw);margin-bottom:24px;text-shadow:0 0 15px rgba(200,68,255,0.6);">\uD83D\uDD13 ${T('levelcomplete.unlocked')}</div>`;
     const nextBtn = isL2Clear ? '' : `<button class="btn" style="background:linear-gradient(180deg,#f0b828,#c87800);border-color:#f0c840;" onclick="startGameWithLevel(2)">\u25B6 ${T('levelcomplete.next')}</button>`;
@@ -185,7 +187,7 @@ function triggerLevelComplete() {
     overlay.innerHTML = `
         <h1 style="color:#44ff88;text-shadow:0 0 30px rgba(68,255,136,0.7);">\uD83C\uDFC6 ${T('levelcomplete.title')}</h1>
         <div style="color:#f0c040;font-size:min(32px,6vw);margin:16px 0;letter-spacing:3px;">${levelTag} ${T('levelcomplete.clear')}</div>
-        <div style="color:#aaa;font-size:min(20px,4vw);margin-bottom:12px;">${T('levelcomplete.waves', g.wave - 1, maxWaves)}</div>
+        <div style="color:#aaa;font-size:min(20px,4vw);margin-bottom:12px;">${T('levelcomplete.waves', Math.min(g.wave, maxWaves), maxWaves)}</div>
         <div style="color:#88ccff;font-size:min(22px,4.5vw);margin-bottom:6px;">${T('levelcomplete.score', g.score)}</div>
         ${unlockLine}
         <div id="menuButtons">
@@ -194,7 +196,16 @@ function triggerLevelComplete() {
             <button class="btn" onclick="restoreMainMenu()">${T('levelcomplete.mainmenu')}</button>
         </div>
     `;
-    saveHighScore(g.score, g.wave - 1);
+    const completedWave = Math.min(g.wave, maxWaves);
+    if (g.currentLevel === 2) {
+        const prev = playerData.l2HighScore || { score: 0, wave: 0 };
+        if (g.score > prev.score || completedWave > prev.wave) {
+            playerData.l2HighScore = { score: g.score, wave: completedWave };
+            savePlayerData(playerData);
+        }
+    } else {
+        saveHighScore(g.score, completedWave);
+    }
     syncHighScore();
     const slotsDiv = document.getElementById('weaponSlots');
     if (slotsDiv) slotsDiv.style.display = 'none';

--- a/docs/js/update.js
+++ b/docs/js/update.js
@@ -10,6 +10,7 @@ function update(dt) {
     updateBulletCollisions(g, dtF);
     updateEnemies(g, dt, dtF, bossAlive);
     updateWorld(g, dt, dtF, bossAlive);
+    if (game !== g) return;
     updateEffects(g, dt, dtF);
 
     flushPlayerDataSave(false);

--- a/docs/js/update_effects.js
+++ b/docs/js/update_effects.js
@@ -179,13 +179,5 @@ function updateEffects(g, dt, dtF) {
         if (c.x > 1.3) c.x = -0.3;
     });
 
-    // Level clear detection
-    if (g.currentLevel === 1 && g.wave > MAX_WAVES_LEVEL1 && !g.levelCompleted) {
-        g.levelCompleted = true;
-        triggerLevelComplete();
-    }
-    if (g.currentLevel === 2 && g.wave > MAX_WAVES_LEVEL2 && !g.levelCompleted) {
-        g.levelCompleted = true;
-        triggerLevelComplete();
-    }
+    completeLevelOnce(g);
 }

--- a/docs/js/update_world.js
+++ b/docs/js/update_world.js
@@ -99,8 +99,11 @@ function updateWorld(g, dt, dtF, bossAlive) {
         }
     });
 
+    if (completeLevelOnce(g)) return;
+
     // Spawning — blocked while boss is alive (must defeat boss before next wave)
     if (!bossAlive && g.cameraZ + CONFIG.SPAWN_DISTANCE > g.nextWaveZ) {
+        if (g.finalWaveSpawned && isFinalWave(g)) return;
         spawnEnemyWave();
         if (Math.random() > 0.55) spawnBarrels();
         g.wave++;
@@ -110,12 +113,14 @@ function updateWorld(g, dt, dtF, bossAlive) {
         if (g.wave === 66 && g.currentLevel === 1) {
             g.preBossSquad = g.squadCount;
             g.squadLostDuringBoss = 0;
+            g.finalWaveSpawned = true;
             const xOff = CONFIG.ROAD_HALF_WIDTH * 0.45;
             spawnMegaBoss(g.nextWaveZ - 80, -xOff);
             spawnMegaBoss(g.nextWaveZ - 80,  xOff);
         } else if (g.wave === 88 && g.currentLevel === 2) {
             g.preBossSquad = g.squadCount;
             g.squadLostDuringBoss = 0;
+            g.finalWaveSpawned = true;
             const xOff = CONFIG.ROAD_HALF_WIDTH * 0.45;
             spawnElephantBoss(g.nextWaveZ - 80, -xOff);
             spawnElephantBoss(g.nextWaveZ - 80,  xOff);

--- a/docs/style.css
+++ b/docs/style.css
@@ -1158,6 +1158,47 @@ html, body {
 }
 
 /* ============================================================
+   CRITICAL ASSET ERROR OVERLAY
+   ============================================================ */
+#assetError {
+    position: fixed;
+    inset: 0;
+    z-index: 100000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(5, 7, 18, 0.96);
+    color: #f4f7ff;
+    font-family: 'Segoe UI', system-ui, sans-serif;
+}
+#assetError.hidden {
+    display: none;
+}
+#assetErrorPanel {
+    width: min(520px, calc(100vw - 32px));
+    border: 1px solid rgba(240, 184, 40, 0.35);
+    background: #111827;
+    border-radius: 8px;
+    padding: 24px;
+    box-shadow: 0 18px 50px rgba(0, 0, 0, 0.45);
+}
+#assetErrorPanel h2 {
+    margin: 0 0 12px;
+    color: #f0b828;
+    font-size: 24px;
+}
+#assetErrorPanel p {
+    color: #aeb8d2;
+    margin: 0 0 14px;
+}
+#assetErrorList {
+    margin: 0 0 20px 20px;
+    padding: 0;
+    color: #ffb3b3;
+    line-height: 1.6;
+}
+
+/* ============================================================
    LEADERBOARD OVERLAY
    ============================================================ */
 #leaderboardOverlay {


### PR DESCRIPTION
## Summary
- Preserve UTF-8 handling for project text files and add repository/editor encoding rules.
- Freeze gameplay updates while paused so world, combat, timers, and cooldowns do not advance behind the pause menu.
- Preserve existing player progress across data version bumps and expose an explicit reset-save helper.
- Remove the runtime anti-debugger trap so DevTools and automated testing are not interrupted.
- Harden audio loading so missing, blocked, or late-loading audio does not stop gameplay.
- Centralize final-wave completion so Level I wave 66 and Level II wave 88 complete exactly once after final bosses are defeated.
- Add critical p5.js/sprite asset load failure handling with a readable error overlay.

## Linked issues
Fixes #40
Fixes #41
Fixes #42
Fixes #43
Fixes #44
Fixes #45
Fixes #46

## Validation
- Ran `git diff --cached --check` successfully before committing.
- Confirmed `Yuri` is pushed and tracking `origin/Yuri`.
- Confirmed local working tree is clean after push.
- JavaScript runtime syntax validation was not run because Node.js is not installed in this workspace.

## Review note
This PR is intentionally opened as a draft so the group can review and discuss before merging into `main`.