### PR TITLE
Remove central card and expand menu monsters to 6

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
 <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="stylesheet" href="style.css?v=13">
+<link rel="stylesheet" href="style.css?v=14">
 <style>
 /* p5.js canvas sits behind all overlays.
    Use "body > canvas" to target only the p5 canvas (direct child of body),
@@ -57,9 +57,12 @@ body > canvas {
 
 <div id="overlay">
     <!-- Decorative animated monster sprites (pure CSS, no interaction) -->
+    <div class="menu-monster monster-elephant-bg" aria-hidden="true"></div>
     <div class="menu-monster monster-dragon-left" aria-hidden="true"></div>
     <div class="menu-monster monster-capybara-right" aria-hidden="true"></div>
     <div class="menu-monster monster-boss-top" aria-hidden="true"></div>
+    <div class="menu-monster monster-fire-top-left" aria-hidden="true"></div>
+    <div class="menu-monster monster-cow-mid-right" aria-hidden="true"></div>
 
     <h1>BRIDGE ASSAULT</h1>
     <h2 data-i18n="menu.subtitle">桥 梁 突 击</h2>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1938,24 +1938,25 @@ body::after {
                    drop-shadow(0 0 56px rgba(220, 60, 20, 0.28)); }
 }
 
-/* --- Elephant (far background, behind title) ---
+/* --- Elephant King (bottom-center, prominent mascot) ---
    Sprite: 3712×128, 29 frames, each 128×128
-   Display: 200×200, extreme low opacity + blur for distant silhouette feel */
+   Display: 160×160, centered between the two bottom monsters */
 .monster-elephant-bg {
-    width: 200px;
-    height: 200px;
+    width: 160px;
+    height: 160px;
     left: 50%;
-    top: 52%;
-    transform: translate(-50%, -50%);
-    opacity: 0.14;
-    filter: blur(1.5px) drop-shadow(0 0 24px rgba(0, 0, 0, 0.6));
-    background: url('assets/elephant.png') 0 0 / 5800px 200px no-repeat;
+    bottom: 2%;
+    transform: translateX(-50%);
+    opacity: 0.55;
+    filter: drop-shadow(0 0 22px rgba(255, 140, 40, 0.25))
+            drop-shadow(0 0 8px rgba(0, 0, 0, 0.5));
+    background: url('assets/elephant.png') 0 0 / 4640px 160px no-repeat;
     animation:
-        sprite-elephant 2.5s steps(29) infinite,
-        float-y 5s ease-in-out infinite alternate;
+        sprite-elephant 2.2s steps(29) infinite,
+        float-y 4.5s ease-in-out infinite alternate;
 }
 @keyframes sprite-elephant {
-    to { background-position: -5800px 0; }
+    to { background-position: -4640px 0; }
 }
 
 /* --- Cow Cry (mid-right, accent creature) ---
@@ -2023,12 +2024,12 @@ body::after {
                                transform: translateX(calc(-50% + 160px)); }
     .monster-fire-top-left   { width: 84px; height: 84px; background-size: 672px  84px; opacity: 0.28;
                                transform: translateX(calc(-50% - 170px)) scaleX(-1); }
-    .monster-elephant-bg     { width: 140px; height: 140px; background-size: 4060px 140px; opacity: 0.10; }
+    .monster-elephant-bg     { width: 110px; height: 110px; background-size: 3190px 110px; opacity: 0.50; }
+    @keyframes sprite-elephant { to { background-position: -3190px 0; } }
     .monster-cow-mid-right   { width: 54px; height: 54px; background-size: 1080px 54px; opacity: 0.35; right: 10%; }
     @keyframes sprite-dragon   { to { background-position: -1344px 0; } }
     @keyframes sprite-capybara { to { background-position: -960px  0; } }
     @keyframes sprite-boss     { to { background-position: -320px  0; } }
     @keyframes sprite-fire     { to { background-position: -672px  0; } }
-    @keyframes sprite-elephant { to { background-position: -4060px 0; } }
     @keyframes sprite-cow      { to { background-position: -1080px 0; } }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -83,24 +83,9 @@ body::after {
         repeating-linear-gradient(90deg, rgba(255,255,255,0.03) 0 1px, transparent 1px 110px);
     opacity: 0.9;
 }
-#overlay::after {
-    width: min(920px, 92vw);
-    height: min(540px, 72vh);
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -47%);
-    border-radius: 32px;
-    border: 1px solid rgba(255,255,255,0.12);
-    background:
-        linear-gradient(180deg, rgba(17, 27, 52, 0.9), rgba(7, 11, 24, 0.78)),
-        radial-gradient(circle at top, rgba(255,255,255,0.08), transparent 58%);
-    box-shadow:
-        0 28px 90px rgba(0,0,0,0.52),
-        inset 0 1px 0 rgba(255,255,255,0.14),
-        inset 0 -1px 0 rgba(255,180,88,0.1);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-}
+/* Central glass card removed — elements now float directly on the atmospheric
+   background for a more open, cinematic feel. The ::before atmospheric layer
+   above is preserved. */
 #overlay > * {
     position: relative;
     z-index: 1;
@@ -263,15 +248,6 @@ body::after {
     align-items: center;
     gap: min(16px, 3vh);
     margin-top: min(24px, 4vh);
-    padding: min(26px, 4vh) min(28px, 5vw);
-    border-radius: 24px;
-    background: linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.015));
-    border: 1px solid rgba(255,255,255,0.08);
-    box-shadow:
-        inset 0 1px 0 rgba(255,255,255,0.08),
-        0 18px 50px rgba(0,0,0,0.24);
-    backdrop-filter: blur(6px);
-    -webkit-backdrop-filter: blur(6px);
 }
 /* Secondary nav row below start button */
 #menuNav {
@@ -1936,6 +1912,71 @@ body::after {
     to { background-position: -1408px 0; }
 }
 
+/* --- Fire Dragon (top-left) ---
+   Sprite: 2048×256, 8 frames, each 256×256
+   Display: 120×120, red/orange glow pulse, mirrors boss on the right */
+.monster-fire-top-left {
+    width: 120px;
+    height: 120px;
+    left: 50%;
+    top: 8%;
+    transform: translateX(calc(-50% - 240px)) scaleX(-1);
+    opacity: 0.32;
+    background: url('assets/fire_enemy.png') 0 0 / 960px 120px no-repeat;
+    animation:
+        sprite-fire 0.9s steps(8) infinite,
+        float-y 3.6s ease-in-out infinite alternate,
+        pulse-glow-fire 2.6s ease-in-out infinite alternate;
+}
+@keyframes sprite-fire {
+    to { background-position: -960px 0; }
+}
+@keyframes pulse-glow-fire {
+    from { filter: drop-shadow(0 0 14px rgba(255, 90, 40, 0.35))
+                   drop-shadow(0 0 36px rgba(200, 40, 20, 0.18)); }
+    to   { filter: drop-shadow(0 0 22px rgba(255, 120, 50, 0.55))
+                   drop-shadow(0 0 56px rgba(220, 60, 20, 0.28)); }
+}
+
+/* --- Elephant (far background, behind title) ---
+   Sprite: 3712×128, 29 frames, each 128×128
+   Display: 200×200, extreme low opacity + blur for distant silhouette feel */
+.monster-elephant-bg {
+    width: 200px;
+    height: 200px;
+    left: 50%;
+    top: 52%;
+    transform: translate(-50%, -50%);
+    opacity: 0.14;
+    filter: blur(1.5px) drop-shadow(0 0 24px rgba(0, 0, 0, 0.6));
+    background: url('assets/elephant.png') 0 0 / 5800px 200px no-repeat;
+    animation:
+        sprite-elephant 2.5s steps(29) infinite,
+        float-y 5s ease-in-out infinite alternate;
+}
+@keyframes sprite-elephant {
+    to { background-position: -5800px 0; }
+}
+
+/* --- Cow Cry (mid-right, accent creature) ---
+   Sprite: 2560×128, 20 frames, each 128×128
+   Display: 76×76, mirrored facing the center */
+.monster-cow-mid-right {
+    width: 76px;
+    height: 76px;
+    right: 14%;
+    top: 42%;
+    transform: scaleX(-1);
+    opacity: 0.42;
+    background: url('assets/cow_cry.png') 0 0 / 1520px 76px no-repeat;
+    animation:
+        sprite-cow 1.6s steps(20) infinite,
+        float-y 2.4s ease-in-out infinite alternate;
+}
+@keyframes sprite-cow {
+    to { background-position: -1520px 0; }
+}
+
 /* --- Boss Dragon (top, near title) ---
    Sprite: 256×64, 4 frames, each 64×64
    Display: 112×112 (scaled up), subtle pulse glow */
@@ -1976,10 +2017,18 @@ body::after {
 }
 /* Small desktop: shrink and fade further */
 @media (max-width: 1100px) and (min-width: 769px) {
-    .monster-dragon-left  { width: 64px; height: 64px; background-size: 1344px 64px; opacity: 0.35; }
-    .monster-capybara-right { width: 60px; height: 60px; background-size: 960px 60px; opacity: 0.32; }
-    .monster-boss-top { width: 80px; height: 80px; background-size: 320px 80px; opacity: 0.30; }
+    .monster-dragon-left     { width: 64px; height: 64px; background-size: 1344px 64px; opacity: 0.35; }
+    .monster-capybara-right  { width: 60px; height: 60px; background-size: 960px  60px; opacity: 0.32; }
+    .monster-boss-top        { width: 80px; height: 80px; background-size: 320px  80px; opacity: 0.30;
+                               transform: translateX(calc(-50% + 160px)); }
+    .monster-fire-top-left   { width: 84px; height: 84px; background-size: 672px  84px; opacity: 0.28;
+                               transform: translateX(calc(-50% - 170px)) scaleX(-1); }
+    .monster-elephant-bg     { width: 140px; height: 140px; background-size: 4060px 140px; opacity: 0.10; }
+    .monster-cow-mid-right   { width: 54px; height: 54px; background-size: 1080px 54px; opacity: 0.35; right: 10%; }
     @keyframes sprite-dragon   { to { background-position: -1344px 0; } }
-    @keyframes sprite-capybara { to { background-position: -960px 0; } }
-    @keyframes sprite-boss     { to { background-position: -320px 0; } }
+    @keyframes sprite-capybara { to { background-position: -960px  0; } }
+    @keyframes sprite-boss     { to { background-position: -320px  0; } }
+    @keyframes sprite-fire     { to { background-position: -672px  0; } }
+    @keyframes sprite-elephant { to { background-position: -4060px 0; } }
+    @keyframes sprite-cow      { to { background-position: -1080px 0; } }
 }


### PR DESCRIPTION
## Summary
Per user feedback, the glass card design at the menu center felt heavy. This PR removes it, letting elements float directly on the atmospheric gradient background. Also expands the menu decorations from 3 to 6 animated monsters for better game-themed ambience.

## Changes

### Card removal
- Delete `#overlay::after` (the 920x540 glass panel)
- Strip `#menuButtons` wrapper (background / border / box-shadow / blur / padding / border-radius)
- Title text-shadow + button gradients carry visual weight on their own

### New monster decorations (3 additional)

| # | Sprite | Position | Notes |
|---|--------|----------|-------|
| 4 | **Fire Dragon** | top-left | 8-frame loop, red/orange pulse, mirrors boss on right |
| 5 | **Elephant King** | bottom-center | 29-frame loop, prominent mascot between the two bottom monsters |
| 6 | **Cow Cry** | mid-right | 20-frame loop, mirrored accent |

Follows same pure-CSS pattern as existing decorations (`background-image` + `steps()` + `pointer-events: none`).

### Other
- Extend small-desktop media query to scale all 6 sprites
- Bump `style.css?v=13` -> `v=14` so returning users pick up the change
- Mobile rule still hides all decorations

## Verification
- Desktop 1440x860 — all 6 monsters visible, buttons clickable (verified via `elementFromPoint` at START button center)
- Small desktop 900x700 — sprites scaled down correctly
- Mobile 375x812 — all decorations hidden, clean menu

Closes nothing (follow-up to #33/#39).