### PR TITLE
Redesign menu with SVG-icon tiles and decorative divider

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
 <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="stylesheet" href="style.css?v=14">
+<link rel="stylesheet" href="style.css?v=15">
 <style>
 /* p5.js canvas sits behind all overlays.
    Use "body > canvas" to target only the p5 canvas (direct child of body),
@@ -66,18 +66,76 @@ body > canvas {
 
     <h1>BRIDGE ASSAULT</h1>
     <h2 data-i18n="menu.subtitle">桥 梁 突 击</h2>
-    <div id="coinDisplay">
-        <span class="coin-icon"><svg viewBox="0 0 18 18" width="18" height="18"><circle cx="9" cy="9" r="8.5" fill="#b8820a"/><circle cx="9" cy="9" r="7" fill="#f0b828"/><ellipse cx="7" cy="6.5" rx="3" ry="1.5" fill="#f8d860" opacity="0.6"/></svg></span>
-        <span id="coinCount">0</span>
-        <span class="gem-icon"><svg viewBox="0 0 18 18" width="18" height="18"><polygon points="9,1 15,7 9,17 3,7" fill="#8822bb"/><polygon points="9,1 15,7 9,9 3,7" fill="#cc44ff"/><polygon points="6,4 12,4 9,1" fill="#ee88ff"/></svg></span>
-        <span id="gemCount" style="color:#cc44ff;">0</span>
-    </div>
     <div id="menuButtons">
-        <button class="btn btn-start" id="startBtn" data-i18n="menu.start">START GAME</button>
+        <button class="btn btn-start" id="startBtn" aria-label="Start game">
+            <span class="btn-start-icon" aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="28" height="28">
+                    <circle cx="16" cy="16" r="13" fill="none" stroke="#231003" stroke-width="2.5"/>
+                    <circle cx="16" cy="16" r="8"  fill="none" stroke="#231003" stroke-width="1.8"/>
+                    <circle cx="16" cy="16" r="2.2" fill="#231003"/>
+                    <rect x="15" y="1"  width="2" height="7" fill="#231003"/>
+                    <rect x="15" y="24" width="2" height="7" fill="#231003"/>
+                    <rect x="1"  y="15" width="7" height="2" fill="#231003"/>
+                    <rect x="24" y="15" width="7" height="2" fill="#231003"/>
+                </svg>
+            </span>
+            <span class="btn-start-label" data-i18n="menu.start">START GAME</span>
+        </button>
+
+        <div class="menu-divider" aria-hidden="true">
+            <span class="menu-divider-dot"></span>
+            <span class="menu-divider-line"></span>
+            <span class="menu-divider-dot"></span>
+        </div>
+
         <div id="menuNav">
-            <button class="btn btn-nav btn-shop" id="shopBtn" data-i18n="menu.shop">SHOP</button>
-            <button class="btn btn-nav btn-achievements" onclick="showAchievementPanel()" data-i18n="menu.achievements">ACHIEVEMENTS</button>
-            <button class="btn btn-nav btn-leaderboard" onclick="showLeaderboard()" data-i18n="menu.leaderboard">LEADERBOARD</button>
+            <button class="btn-tile btn-shop" id="shopBtn" aria-label="Open shop">
+                <span class="tile-icon" aria-hidden="true">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="30" height="30">
+                        <path d="M9 11 L16 4 L23 11" stroke="#ffd966" stroke-width="2" fill="none" stroke-linejoin="round"/>
+                        <rect x="5" y="11" width="22" height="16" rx="2" fill="#7f68ff"/>
+                        <rect x="5" y="11" width="22" height="3" fill="#9d86ff"/>
+                        <rect x="14" y="15" width="4" height="10" rx="1" fill="#ffd966"/>
+                        <circle cx="16" cy="19" r="1.5" fill="#231003"/>
+                    </svg>
+                </span>
+                <span class="tile-label" data-i18n="menu.shop">SHOP</span>
+            </button>
+            <button class="btn-tile btn-achievements" onclick="showAchievementPanel()" aria-label="View achievements">
+                <span class="tile-icon" aria-hidden="true">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="30" height="30">
+                        <path d="M8 6 H24 V12 Q24 18 16 20 Q8 18 8 12 Z" fill="#ffd14a" stroke="#8a5a00" stroke-width="1.5" stroke-linejoin="round"/>
+                        <path d="M6 7 Q2 8 3 12 Q4 15 8 14" fill="none" stroke="#ffd14a" stroke-width="2"/>
+                        <path d="M26 7 Q30 8 29 12 Q28 15 24 14" fill="none" stroke="#ffd14a" stroke-width="2"/>
+                        <rect x="13" y="20" width="6" height="4" fill="#b78417"/>
+                        <rect x="10" y="24" width="12" height="3" rx="1" fill="#8a5a00"/>
+                        <polygon points="16,8 17.2,11 20.2,11 17.7,13 18.7,16 16,14.2 13.3,16 14.3,13 11.8,11 14.8,11"
+                                 fill="#fff2a8"/>
+                    </svg>
+                </span>
+                <span class="tile-label" data-i18n="menu.achievements">ACHIEVEMENTS</span>
+            </button>
+            <button class="btn-tile btn-leaderboard" onclick="showLeaderboard()" aria-label="View leaderboard">
+                <span class="tile-icon" aria-hidden="true">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="30" height="30">
+                        <rect x="4"  y="18" width="7" height="9"  rx="1" fill="#3d84c4"/>
+                        <rect x="12" y="10" width="7" height="17" rx="1" fill="#5aa7ee"/>
+                        <rect x="20" y="14" width="7" height="13" rx="1" fill="#3d84c4"/>
+                        <polygon points="15.5,4 17,7 20,7.5 17.8,9.8 18.4,13 15.5,11.5 12.6,13 13.2,9.8 11,7.5 14,7"
+                                 fill="#ffd966"/>
+                        <rect x="3" y="27" width="26" height="2" rx="1" fill="#d8f0ff"/>
+                    </svg>
+                </span>
+                <span class="tile-label" data-i18n="menu.leaderboard">LEADERBOARD</span>
+            </button>
+        </div>
+
+        <div id="coinDisplay">
+            <span class="coin-icon"><svg viewBox="0 0 18 18" width="16" height="16"><circle cx="9" cy="9" r="8.5" fill="#b8820a"/><circle cx="9" cy="9" r="7" fill="#f0b828"/><ellipse cx="7" cy="6.5" rx="3" ry="1.5" fill="#f8d860" opacity="0.6"/></svg></span>
+            <span id="coinCount">0</span>
+            <span class="coin-sep" aria-hidden="true">·</span>
+            <span class="gem-icon"><svg viewBox="0 0 18 18" width="16" height="16"><polygon points="9,1 15,7 9,17 3,7" fill="#8822bb"/><polygon points="9,1 15,7 9,9 3,7" fill="#cc44ff"/><polygon points="6,4 12,4 9,1" fill="#ee88ff"/></svg></span>
+            <span id="gemCount" style="color:#cc44ff;">0</span>
         </div>
     </div>
 </div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -136,9 +136,13 @@ body::after {
         inset 0 1px 0 rgba(255,255,255,0.45);
 }
 #overlay .btn:active { transform: scale(0.95); }
-/* Primary start button — large and prominent */
+/* Primary start button — large and prominent, with crosshair icon */
 #overlay .btn-start {
-    padding: min(22px, 4.5vw) min(70px, 15vw);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    padding: min(22px, 4.5vw) min(60px, 13vw);
     font-size: min(30px, 6vw);
     letter-spacing: 4px;
     border-radius: 14px;
@@ -148,6 +152,17 @@ body::after {
         0 18px 36px rgba(0,0,0,0.38),
         0 0 24px rgba(255, 188, 63, 0.24),
         inset 0 1px 0 rgba(255,255,255,0.45);
+}
+#overlay .btn-start-icon {
+    display: inline-flex;
+    align-items: center;
+    transition: transform 0.25s ease;
+}
+#overlay .btn-start:hover .btn-start-icon {
+    transform: rotate(45deg) scale(1.08);
+}
+#overlay .btn-start-label {
+    line-height: 1;
 }
 #scoreDisplay { color: #f0c040; font-size: min(28px, 5vw); margin: 16px 0 8px; }
 #finalScore { color: #fff; font-size: min(56px, 10vw); margin: 8px 0 20px; font-weight: bold; text-shadow: 0 0 15px rgba(255,255,255,0.3); }
@@ -224,21 +239,31 @@ body::after {
 /* ============================================================
    COIN DISPLAY (on overlay)
    ============================================================ */
+/* Currency badges — small pill below nav tiles */
 #coinDisplay {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 8px;
-    margin-bottom: min(24px, 3vh);
-    font-size: min(24px, 5vw);
+    margin-top: 14px;
+    padding: 6px 14px;
+    font-size: 14px;
+    font-family: 'Courier New', monospace;
+    font-weight: bold;
     color: #ffd700;
-    text-shadow: 0 0 10px rgba(255,215,0,0.5);
+    background: rgba(12, 14, 28, 0.55);
+    border: 1px solid rgba(255, 215, 0, 0.25);
+    border-radius: 999px;
+    text-shadow: 0 0 6px rgba(255,215,0,0.35);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
 }
 .coin-icon, .gem-icon {
-    display: flex;
+    display: inline-flex;
     align-items: center;
 }
-.gem-icon {
-    margin-left: 8px;
+.coin-sep {
+    color: rgba(255,255,255,0.25);
+    margin: 0 2px;
 }
 
 /* Main menu button group — vertical stack */
@@ -249,38 +274,111 @@ body::after {
     gap: min(16px, 3vh);
     margin-top: min(24px, 4vh);
 }
-/* Secondary nav row below start button */
+/* Decorative divider between START button and nav tiles */
+.menu-divider {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: min(340px, 60vw);
+    margin: 4px 0 2px;
+    opacity: 0.8;
+    pointer-events: none;
+}
+.menu-divider-line {
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(90deg,
+        transparent 0%,
+        rgba(255, 210, 120, 0.45) 30%,
+        rgba(255, 210, 120, 0.45) 70%,
+        transparent 100%);
+}
+.menu-divider-dot {
+    width: 6px;
+    height: 6px;
+    transform: rotate(45deg);
+    background: rgba(255, 210, 120, 0.8);
+    box-shadow: 0 0 8px rgba(255, 200, 90, 0.45);
+}
+
+/* Secondary nav row: 3 icon tiles below start button */
 #menuNav {
     display: flex;
-    gap: min(12px, 2.5vw);
-    flex-wrap: wrap;
+    gap: min(14px, 2.5vw);
     justify-content: center;
+    align-items: stretch;
 }
-#overlay .btn-nav {
-    padding: min(10px, 2.2vw) min(22px, 4.5vw);
-    font-size: min(14px, 3vw);
-    letter-spacing: 1px;
-    border-width: 1px;
-    min-width: min(160px, 28vw);
+.btn-tile {
+    --tile-color: #888;
+    --tile-glow: rgba(120,120,120,0.4);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: min(118px, 24vw);
+    padding: 14px 10px 12px;
+    font-family: 'Courier New', monospace;
+    font-weight: bold;
+    font-size: min(11px, 2.4vw);
+    letter-spacing: 1.5px;
+    color: #ffffff;
+    background: linear-gradient(180deg,
+        color-mix(in srgb, var(--tile-color) 22%, rgba(12, 14, 28, 0.75)) 0%,
+        color-mix(in srgb, var(--tile-color) 10%, rgba(6, 8, 18, 0.85)) 100%);
+    border: 1.5px solid color-mix(in srgb, var(--tile-color) 55%, rgba(255,255,255,0.15));
+    border-radius: 14px;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.18s ease,
+                border-color 0.18s ease, background 0.18s ease;
+    -webkit-tap-highlight-color: transparent;
+    box-shadow:
+        0 8px 22px rgba(0,0,0,0.38),
+        inset 0 1px 0 rgba(255,255,255,0.08);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
 }
-.btn-shop {
-    background: linear-gradient(180deg, #7f68ff, #4636cb) !important;
-    border-color: rgba(159, 139, 255, 0.95) !important;
-    color: #fff !important;
+.btn-tile:hover {
+    transform: translateY(-4px);
+    border-color: color-mix(in srgb, var(--tile-color) 90%, white);
+    box-shadow:
+        0 16px 32px rgba(0,0,0,0.46),
+        0 0 22px var(--tile-glow),
+        inset 0 1px 0 rgba(255,255,255,0.14);
 }
-.btn-shop:hover { transform: scale(1.05); }
-.btn-achievements {
-    background: linear-gradient(180deg, #f0bc43, #b78417) !important;
-    border-color: rgba(255, 217, 109, 0.9) !important;
-    color: #1a0a00 !important;
+.btn-tile:active {
+    transform: translateY(-1px) scale(0.97);
 }
-.btn-leaderboard {
-    background: linear-gradient(180deg, #2a618e, #17314f) !important;
-    border-color: rgba(121, 188, 255, 0.9) !important;
-    color: #d8f0ff !important;
+.btn-tile:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--tile-color) 95%, white);
+    outline-offset: 3px;
 }
+.tile-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    filter: drop-shadow(0 2px 6px rgba(0,0,0,0.4));
+    transition: transform 0.2s ease;
+}
+.btn-tile:hover .tile-icon {
+    transform: scale(1.12) translateY(-1px);
+}
+.tile-label {
+    line-height: 1;
+    text-shadow: 0 1px 2px rgba(0,0,0,0.6);
+}
+
+/* Per-tile accent colors — drive the --tile-color custom prop */
+.btn-shop        { --tile-color: #8a72ff; --tile-glow: rgba(138, 114, 255, 0.38); }
+.btn-achievements{ --tile-color: #f0bc43; --tile-glow: rgba(240, 188, 67,  0.42); color: #fff3c5; }
+.btn-leaderboard { --tile-color: #4a93d4; --tile-glow: rgba(90, 167, 238,  0.42); color: #d8f0ff; }
+
 .btn-achievements.has-unclaimed {
-    box-shadow: 0 0 12px #ffd700;
+    animation: tile-pulse 2.1s ease-in-out infinite;
+}
+@keyframes tile-pulse {
+    0%, 100% { box-shadow: 0 8px 22px rgba(0,0,0,0.38), 0 0 10px rgba(255, 215, 0, 0.4), inset 0 1px 0 rgba(255,255,255,0.08); }
+    50%      { box-shadow: 0 8px 22px rgba(0,0,0,0.38), 0 0 22px rgba(255, 215, 0, 0.8), inset 0 1px 0 rgba(255,255,255,0.14); }
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary
Rework the main-menu button area to feel more arcade-themed and give each action an identifiable icon. Replaces the plain text row with a primary button (with icon) + 3 accent-colored icon tiles + decorative divider.

![before-after](https://github.com/UoB-COMSM0166/2026-group-25/pull/48)

## Changes

### Buttons
| Button | Icon | Accent |
|--------|------|--------|
| START GAME | crosshair (rotates 45 on hover) | gold |
| SHOP | shop/bag with gold handle | purple |
| ACHIEVEMENTS | trophy with star | gold |
| LEADERBOARD | 3-bar podium with gold star | blue |

All icons are inline SVGs in the same chunky style as the existing \`WEAPON_ICONS\` in \`config.js\`.

### Layout
```
           BRIDGE ASSAULT
           WAVE DEFENSE

       [ (o) START GAME ]
      ◆  ───────  ◆              <- decorative divider
  [ SHOP ] [ ACH ] [ LEADER ]
         \u{1FA99} 0 · \u{1F48E} 0       <- currency pill
```

### Accessibility
- Every button has \`aria-label\`
- Every decorative SVG has \`aria-hidden=\"true\"\`
- \`:focus-visible\` outline per-tile accent color
- Labels preserved for screen readers (not icon-only)

### Cache-buster
\`style.css?v=14\` → \`v=15\` so returning players pick up the new CSS immediately.

## Test Plan
- [x] Desktop 1440x860 — all 4 buttons visible with icons, divider renders, coin pill below
- [x] Desktop (hover) — tiles lift + glow per color
- [x] Small desktop 900x700 — tiles scale, still three columns
- [x] Mobile 375x812 — monsters hidden, buttons remain tappable
- [x] Returning cache-warm browser — cache-bust forces reload

Closes #49