### PR TITLE
Fix main menu reverting to old layout after returning from game

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -67,7 +67,7 @@ body > canvas {
     <h1>BRIDGE ASSAULT</h1>
     <h2 data-i18n="menu.subtitle">桥 梁 突 击</h2>
     <div id="menuButtons">
-        <button class="btn btn-start" id="startBtn" aria-label="Start game">
+        <button class="btn btn-start" id="startBtn" onclick="showLevelSelect()" aria-label="Start game">
             <span class="btn-start-icon" aria-hidden="true">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="28" height="28">
                     <circle cx="16" cy="16" r="13" fill="none" stroke="#231003" stroke-width="2.5"/>
@@ -89,7 +89,7 @@ body > canvas {
         </div>
 
         <div id="menuNav">
-            <button class="btn-tile btn-shop" id="shopBtn" aria-label="Open shop">
+            <button class="btn-tile btn-shop" id="shopBtn" onclick="openShop()" aria-label="Open shop">
                 <span class="tile-icon" aria-hidden="true">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="30" height="30">
                         <path d="M9 11 L16 4 L23 11" stroke="#ffd966" stroke-width="2" fill="none" stroke-linejoin="round"/>

--- a/docs/js/globals.js
+++ b/docs/js/globals.js
@@ -49,6 +49,13 @@ const keys = {};
 const overlay = document.getElementById('overlay');
 const startBtn = document.getElementById('startBtn');
 
+// Snapshot of the pristine main-menu markup. Captured at page load (before
+// any user interaction or dynamic writes) so that returning to the menu
+// after game over / level select / pause restores the exact same layout
+// authored in index.html (monster decorations, SVG icon tiles, divider,
+// currency pill). See restoreMainMenu() in ui.js.
+const MAIN_MENU_TEMPLATE = overlay ? overlay.innerHTML : '';
+
 // ============================================================
 // PERSISTENT DATA (localStorage)
 // ============================================================

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -565,24 +565,27 @@ function showGameOver() {
 }
 
 function restoreMainMenu() {
-    overlay.innerHTML = `
-        <h1>BRIDGE ASSAULT</h1>
-        <h2 data-i18n="menu.subtitle">${T('menu.subtitle')}</h2>
-        <div id="coinDisplay">
-            <span class="coin-icon"><svg viewBox="0 0 18 18" width="18" height="18" style="vertical-align:-3px"><circle cx="9" cy="9" r="8.5" fill="#b8820a"/><circle cx="9" cy="9" r="7" fill="#f0b828"/><ellipse cx="7" cy="6.5" rx="3" ry="1.5" fill="#f8d860" opacity="0.6"/></svg></span>
-            <span id="coinCount">${playerData.coins}</span>
-            <span style="margin-left:14px"><svg viewBox="0 0 16 16" width="16" height="16" style="vertical-align:-3px"><polygon points="8,1 14,6 8,15 2,6" fill="#8822bb"/><polygon points="8,1 14,6 8,8 2,6" fill="#cc44ff"/><polygon points="5.5,3.5 10.5,3.5 8,1" fill="#ee88ff"/></svg></span>
-            <span id="gemCount" style="color:#cc44ff;">${playerData.gems || 0}</span>
-        </div>
-        <div id="menuButtons">
-            <button class="btn btn-start" onclick="showLevelSelect()" data-i18n="menu.start">${T('menu.start')}</button>
-            <div id="menuNav">
-                <button class="btn btn-nav btn-shop" onclick="openShop()" data-i18n="menu.shop">${T('menu.shop')}</button>
-                <button class="btn btn-nav btn-achievements${_hasUnclaimedAch() ? ' has-unclaimed' : ''}" onclick="showAchievementPanel()" data-i18n="menu.achievements">${T('menu.achievements')}</button>
-                <button class="btn btn-nav btn-leaderboard" onclick="showLeaderboard()" data-i18n="menu.leaderboard">${T('menu.leaderboard')}</button>
-            </div>
-        </div>
-    `;
+    // Restore the pristine menu markup captured at page load in globals.js.
+    // This keeps the layout in sync with index.html automatically — no need
+    // to maintain a second copy of the menu HTML here that silently drifts
+    // out of date whenever the menu is redesigned.
+    if (MAIN_MENU_TEMPLATE) {
+        overlay.innerHTML = MAIN_MENU_TEMPLATE;
+    }
+
+    // Re-apply dynamic state that isn't part of the template:
+    //   - current coin/gem counts (template shipped with placeholder 0/0)
+    //   - unclaimed-achievement pulse class
+    //   - i18n text for current language (template has zh text by default)
+    const coinEl = document.getElementById('coinCount');
+    if (coinEl) coinEl.textContent = playerData.coins;
+    const gemEl = document.getElementById('gemCount');
+    if (gemEl) gemEl.textContent = playerData.gems || 0;
+
+    const achBtn = overlay.querySelector('.btn-achievements');
+    if (achBtn) achBtn.classList.toggle('has-unclaimed', _hasUnclaimedAch());
+
+    if (typeof applyLang === 'function') applyLang();
 }
 
 // ============================================================


### PR DESCRIPTION
## Problem
After #50, returning to the main menu (from level select back button, game over, level complete, or pause menu \u2192 main menu) replaced the overlay with a stale, pre-#50 layout: monsters gone, SVG icon tiles reverted to plain text buttons, crosshair icon on START missing, divider missing, coin pill out of place.

## Root cause
\`restoreMainMenu()\` in \`docs/js/ui.js\` **hardcoded a copy of the menu HTML** that had not been updated when the menu was redesigned. Every invocation rewrote \`#overlay.innerHTML\` with that stale snapshot.

## Fix
Stop maintaining a second copy of the menu markup inside JS. Instead:

1. **\`globals.js\`**: snapshot \`#overlay.innerHTML\` into \`MAIN_MENU_TEMPLATE\` at page load, before any dynamic writes.
2. **\`ui.js\`**: \`restoreMainMenu()\` now restores from that snapshot, then re-applies the three things that aren't part of the static template:
   - Current coin / gem counts
   - \`has-unclaimed\` class on achievements tile
   - Current language via \`applyLang()\`
3. **\`index.html\`**: add inline \`onclick\` on \`#startBtn\` and \`#shopBtn\` so the buttons remain clickable after innerHTML restore (the \`addEventListener\` bindings attach to the original DOM nodes and are lost during re-render).

Going forward the menu markup lives in **one place** (index.html). Any future menu change is automatically reflected in the restored state.

## Test Plan
Verified via preview MCP with `preview_eval`:
\`\`\`
{ hasMonsters: 6, hasTiles: 3, hasDivider: true, startBtnHasIcon: true, coinDisplayParent: 'menuButtons' }
\`\`\`
after START \u2192 back round-trip. Visually confirmed via screenshot: full layout restored including all 6 monster sprites.

Closes #51