### PR TITLE
Bump JS cache-buster to v=28 to force refresh of menu fix

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=27"></script>
-<script src="js/config.js?v=27"></script>
-<script src="js/i18n.js?v=27"></script>
-<script src="js/globals.js?v=27"></script>
-<script src="js/audio.js?v=27"></script>
-<script src="js/core.js?v=27"></script>
-<script src="js/helpers.js?v=27"></script>
-<script src="js/spawn.js?v=27"></script>
-<script src="js/combat.js?v=27"></script>
-<script src="js/draw.js?v=27"></script>
-<script src="js/hud.js?v=27"></script>
-<script src="js/update_timers.js?v=27"></script>
-<script src="js/update_collision.js?v=27"></script>
-<script src="js/update_enemies.js?v=27"></script>
-<script src="js/update_world.js?v=27"></script>
-<script src="js/update_effects.js?v=27"></script>
-<script src="js/update.js?v=27"></script>
-<script src="js/render.js?v=27"></script>
-<script src="js/achievements.js?v=27"></script>
-<script src="js/shop.js?v=27"></script>
-<script src="js/leaderboard.js?v=27"></script>
-<script src="js/input.js?v=27"></script>
-<script src="js/ui.js?v=27"></script>
-<script src="js/tutorial.js?v=27"></script>
-<script src="js/main.js?v=27"></script>
+<script src="js/crypto.js?v=28"></script>
+<script src="js/config.js?v=28"></script>
+<script src="js/i18n.js?v=28"></script>
+<script src="js/globals.js?v=28"></script>
+<script src="js/audio.js?v=28"></script>
+<script src="js/core.js?v=28"></script>
+<script src="js/helpers.js?v=28"></script>
+<script src="js/spawn.js?v=28"></script>
+<script src="js/combat.js?v=28"></script>
+<script src="js/draw.js?v=28"></script>
+<script src="js/hud.js?v=28"></script>
+<script src="js/update_timers.js?v=28"></script>
+<script src="js/update_collision.js?v=28"></script>
+<script src="js/update_enemies.js?v=28"></script>
+<script src="js/update_world.js?v=28"></script>
+<script src="js/update_effects.js?v=28"></script>
+<script src="js/update.js?v=28"></script>
+<script src="js/render.js?v=28"></script>
+<script src="js/achievements.js?v=28"></script>
+<script src="js/shop.js?v=28"></script>
+<script src="js/leaderboard.js?v=28"></script>
+<script src="js/input.js?v=28"></script>
+<script src="js/ui.js?v=28"></script>
+<script src="js/tutorial.js?v=28"></script>
+<script src="js/main.js?v=28"></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem
PR #52 (restoreMainMenu fix) shipped the JS changes but did not bump the \`?v=\` query string on \`<script src=\"...\">\` tags in \`index.html\`. Returning visitors' browsers kept serving the cached \`v=27\` copies of \`globals.js\` and \`ui.js\`, so they continue to see the broken post-game menu even though the fix is deployed.

## Fix
Bump all 25 JS imports \`v=27\` -> \`v=28\`. Next visit, every user's browser will bypass cache and pull the fixed code.

## Note for future PRs
Any PR that touches a file in \`docs/js/\` MUST bump this version, otherwise returning players won't see the change until their browser's cache expires naturally (can be days).