### PR TITLE
Fix Level 2 completion high score slot, Closes #54

### DIFF
--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -194,7 +194,15 @@ function triggerLevelComplete() {
             <button class="btn" onclick="restoreMainMenu()">${T('levelcomplete.mainmenu')}</button>
         </div>
     `;
-    saveHighScore(g.score, g.wave - 1);
+    if (isL2Clear) {
+        const prev = playerData.l2HighScore || { score: 0, wave: 0 };
+        if (g.score > prev.score) {
+            playerData.l2HighScore = { score: g.score, wave: g.wave - 1 };
+            savePlayerData(playerData);
+        }
+    } else {
+        saveHighScore(g.score, g.wave - 1);
+    }
     syncHighScore();
     const slotsDiv = document.getElementById('weaponSlots');
     if (slotsDiv) slotsDiv.style.display = 'none';


### PR DESCRIPTION
## Summary

This PR fixes Issue #54 by making the Level 2 completion flow save the final score to the dedicated Level 2 high score record instead of always using the default high score slot.

Previously, `triggerLevelComplete()` always called `saveHighScore(...)`, which could store Level 2 completion results in the wrong place.

Closes #54

## What Changed

- updated `triggerLevelComplete()` to save Level 2 completion scores into `playerData.l2HighScore`
- kept the original default high score path for Level 1

## Files Changed

- `docs/js/ui.js`

## Testing

Manual verification target:

1. Start Level 2.
2. Complete the full level.
3. Reach the level-complete screen.
4. Return to level select.
5. Confirm the Level 2 best score is updated in the correct record slot.
