### PR TITLE
Fix Level 2 game over record display, Closes #63

### DIFF
--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -540,7 +540,9 @@ function showGameOver() {
         isNewRecord = saveHighScore(game.score, game.wave);
     }
     syncHighScore();
-    const hs = getHighScore();
+    const hs = currentLvl === 2
+        ? (playerData.l2HighScore || { score: 0, wave: 0 })
+        : getHighScore();
     overlay.classList.remove('hidden');
     document.getElementById('midShopOverlay').classList.add('hidden');
     const slotsDiv = document.getElementById('weaponSlots');


### PR DESCRIPTION
## Summary

This PR fixes Issue #63 by making the Level 2 game-over screen display the Level 2 record instead of always using the default high score source.

Previously, the Level 2 result flow updated `playerData.l2HighScore`, but the record line in the game-over overlay still used `getHighScore()`, which could show the wrong value.

Closes #63

## What Changed

- updated `showGameOver()` to choose the displayed record source based on the current level
- Level 2 now shows `playerData.l2HighScore`
- other levels keep using the default high score source

## Files Changed

- `docs/js/ui.js`

## Testing

Manual verification target:

1. Start a Level 2 run.
2. Reach game over after setting a new Level 2 personal best.
3. Check the record line in the game-over overlay.
4. Confirm it matches the Level 2 record instead of the default high score slot.
