### PR TITLE
Fix tutorial pause menu high score saving, Closes #67

### DIFF
--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -34,8 +34,10 @@ function menuFromPause() {
         playerData.exp = game.exp;
         flushPlayerDataSave(true);
         savePlayerData(playerData);
-        saveHighScore(game.score, game.wave);
-        syncHighScore();
+        if (!game.isTutorial) {
+            saveHighScore(game.score, game.wave);
+            syncHighScore();
+        }
     }
     const slotsDiv = document.getElementById('weaponSlots');
     if (slotsDiv) slotsDiv.style.display = 'none';


### PR DESCRIPTION
## Summary

This PR fixes Issue #67 by preventing tutorial runs from going through the normal high score save and leaderboard sync flow when exiting via the pause menu.

Previously, leaving the tutorial through the pause menu could save tutorial score data as if it were a normal run.

Closes #67

## What Changed

- added a tutorial guard in `menuFromPause()`
- tutorial runs now skip normal `saveHighScore(...)`
- tutorial runs now skip `syncHighScore()`

## Files Changed

- `docs/js/ui.js`

## Testing

Manual verification target:

1. Start the tutorial.
2. Gain a non-zero score.
3. Open the pause menu.
4. Return to the main menu.
5. Confirm the normal high score / leaderboard data is unchanged.
