### PR TITLE
Fix "Shortgun" typo in weapon HUD labels, Closes #69

### DIFF
--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -387,7 +387,7 @@ function initWeaponSlots() {
     slotsDiv.appendChild(currentBadge);
     const orderedTempWeapons = ['shotgun', 'laser', 'rocket'];
     const tempWeaponDisplayNames = {
-        shotgun: 'Shortgun',
+        shotgun: 'Shotgun',
         laser: 'Laser',
         rocket: 'Rocket',
     };
@@ -452,7 +452,7 @@ function _getCurrentWeaponDisplay() {
 
     const def = SHOP_WEAPONS[wKey] || {};
     const tempWeaponDisplayNames = {
-        shotgun: 'Shortgun',
+        shotgun: 'Shotgun',
         laser: 'Laser',
         rocket: 'Rocket',
     };
@@ -542,7 +542,7 @@ function updateWeaponSlots() {
             const isGateActive = g.weapon === key && g.weaponTimer > 0;
             const levelEl = slot.querySelector('.wslot-level');
             const tempWeaponDisplayNames = {
-                shotgun: 'Shortgun',
+                shotgun: 'Shotgun',
                 laser: 'Laser',
                 rocket: 'Rocket',
             };


### PR DESCRIPTION
## Summary
The current-weapon badge and the weapon-slot panel were rendering the shotgun's display name as `Shortgun`. Three `tempWeaponDisplayNames` lookup tables in `docs/js/ui.js` had the typo (lines 390, 455, 545).

This PR fixes all three occurrences so the HUD reads `Shotgun`.

## Test plan
- [ ] Walk through a SHOTGUN gate during a run; confirm the current-weapon badge reads "Shotgun".
- [ ] Open the weapon-slot panel; confirm the shotgun slot label reads "Shotgun".
- [ ] Search the repo for `Shortgun` — no remaining matches.

Closes #69