### PR TITLE
Remove duplicate shopBtn/shopBackBtn click listeners, Closes #71

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -45,9 +45,13 @@ function setup() {
     initAudio();
     setupInput();
 
-    // Shop buttons
-    document.getElementById('shopBtn') && document.getElementById('shopBtn').addEventListener('click', openShop);
-    document.getElementById('shopBackBtn') && document.getElementById('shopBackBtn').addEventListener('click', closeShop);
+    // Shop buttons — #shopBtn / #shopBackBtn already wired via inline
+    // onclick in index.html; only bind the elements that have no inline handler.
+    const midShopGoBtn = document.getElementById('midShopGoBtn');
+    if (midShopGoBtn) midShopGoBtn.addEventListener('click', closeMidShop);
+    document.querySelectorAll('.shop-tab').forEach(btn => {
+        btn.addEventListener('click', () => switchShopTab(btn.dataset.tab));
+    });
 
     // Start button
     const startBtnEl = document.getElementById('startBtn');

--- a/docs/js/shop.js
+++ b/docs/js/shop.js
@@ -453,11 +453,6 @@ function closeMidShop() {
     document.getElementById('midShopOverlay').classList.add('hidden');
 }
 
-// Initialize shop events
+// Initialize shop currencies; click handlers are bound in main.js setup()
+// (or via inline onclick in index.html) so they only attach once.
 updateShopCurrencies();
-document.getElementById('shopBtn').addEventListener('click', openShop);
-document.getElementById('shopBackBtn').addEventListener('click', closeShop);
-document.getElementById('midShopGoBtn').addEventListener('click', closeMidShop);
-document.querySelectorAll('.shop-tab').forEach(btn => {
-    btn.addEventListener('click', () => switchShopTab(btn.dataset.tab));
-});


### PR DESCRIPTION
## Summary
`#shopBtn` was wired up three times (inline onclick + main.js setup + shop.js module-level), and `#shopBackBtn` twice. Each click ran `openShop()`/`closeShop()` 2-3 times.

This PR consolidates listener registration:
- Drop the duplicate `addEventListener` calls for `#shopBtn`/`#shopBackBtn` in `main.js` — the inline `onclick="openShop()"` / `onclick="closeShop()"` in `index.html` already covers them.
- Drop the entire module-level event binding block at the bottom of `shop.js` (which would also re-stack listeners if the module ever ran twice).
- Move `#midShopGoBtn` and `.shop-tab` bindings into `main.js setup()` so registration happens once when the DOM is ready.

`updateShopCurrencies()` is still called at module load to populate the currency badge before `setup()` runs.

## Test plan
- [ ] Open the main menu, click **Shop** once, confirm only one shop overlay opens (no flicker / double-render).
- [ ] Click **Back** in the shop, confirm only one close.
- [ ] Switch shop tabs (Weapon / Special / Talent / Defense), confirm all four tabs still work.
- [ ] After a mega-boss kill, the mid-shop "Continue Combat" button still closes the mid-shop.

Closes #71