### PR TITLE
Remove unused hud.panel.show.short / hide.short translation keys, Closes #73

### DIFF
--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -214,8 +214,6 @@ const TRANSLATIONS = {
         'hud.current.weapon.temp': '临时',
         'hud.panel.show':       '显示武器面板',
         'hud.panel.hide':       '收起武器面板',
-    'hud.panel.show.short': 'Show Weapons',
-    'hud.panel.hide.short': 'Hide Weapons',
 
         // Weapon names & descriptions
         'weapon.shotgun.name':        '霰弹枪',
@@ -483,8 +481,6 @@ const TRANSLATIONS = {
         'hud.current.weapon.temp': 'TEMP',
         'hud.panel.show':       'Show weapon panel',
         'hud.panel.hide':       'Hide weapon panel',
-    'hud.panel.show.short': 'Show Weapons',
-    'hud.panel.hide.short': 'Hide Weapons',
 
         // Weapon names & descriptions
         'weapon.shotgun.name':        'Shotgun',


### PR DESCRIPTION
## Summary
`hud.panel.show.short` and `hud.panel.hide.short` were defined four times in `docs/js/i18n.js` (lines 217-218 zh + 486-487 en) but never referenced. The weapon-panel toggle uses `hud.panel.show` / `hud.panel.hide` (no suffix) in `ui.js`.

The two entries inside the Chinese block also stored English values (`'Show Weapons'` / `'Hide Weapons'`), so any future caller that picked up these keys would have shown English text to zh-CN users.

## Fix
Delete the four `.short` lines.

## Test plan
- [ ] `grep -rn 'hud.panel.show.short\|hud.panel.hide.short' docs/` returns no matches.
- [ ] Weapon-panel toggle button still shows the correct localized tooltip on both EN and ZH.

Closes #73