### PR TITLE
Remove duplicate startBtn click listener, Closes #75

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -53,9 +53,7 @@ function setup() {
         btn.addEventListener('click', () => switchShopTab(btn.dataset.tab));
     });
 
-    // Start button
-    const startBtnEl = document.getElementById('startBtn');
-    if (startBtnEl) startBtnEl.addEventListener('click', showLevelSelect);
+    // #startBtn is wired via inline onclick in index.html — no JS binding here.
 
     // Update coin/gem display on menu
     const coinCountEl = document.getElementById('coinCount');


### PR DESCRIPTION
## Summary
`#startBtn` was running `showLevelSelect()` twice per click — once via the inline `onclick="showLevelSelect()"` in `index.html`, then again via an `addEventListener` call in `main.js setup()`.

This is the same pattern that #71 fixed for the shop buttons. Drop the JS-side binding and let the inline onclick handle it.

## Test plan
- [ ] Open the main menu, click **Start**, confirm only one level-select transition runs (no double overlay flicker).
- [ ] Level-select overlay opens correctly and the back-to-menu flow still works.

Closes #75