### PR TITLE
Fix multi-boss gem drop guard

### DIFF
--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -216,10 +216,9 @@ function spawnBossGems(x, z) {
     const bossLvl = Math.floor(g.wave / 5);
     const isL2 = g.currentLevel === 2;
     // Multi-boss: only the last boss drops gems (max 1 gem drop per wave)
-    const bossCount = Math.min(1 + Math.floor((bossLvl - 1) / 2), 4);
-    const aliveBosses = g.enemies.filter(e => e.alive && e.isBoss).length;
+    const otherBossAlive = g.enemies.some(e => e.alive && e.isBoss);
     // Only drop gems when the last boss dies
-    if (aliveBosses > 1) return;
+    if (otherBossAlive) return;
     // Drop chance: L1: wave5=20%...wave25+=75%; L2 +25%
     const gemDropChance = Math.min(0.97, 0.0 + bossLvl * 0.2 + (isL2 ? 0.25 : 0));
     if (Math.random() > gemDropChance) return;


### PR DESCRIPTION
## Summary
- Fix multi-boss gem drops so only the final surviving boss in a wave can roll boss gems.
- Remove the now-unused boss-count calculation from `spawnBossGems`.

## Why
`processEnemyKill` marks the killed boss dead before calling the gem-drop helper. In a two-boss wave, the old `aliveBosses > 1` guard let the first boss death pass because only one other boss remained alive.

## Test plan
- `for f in docs/js/*.js; do node --check "$f" || exit 1; done`
- `git diff --check`

Closes #77
