### PR TITLE
Fix mega boss breath warning text

### DIFF
--- a/docs/js/update_enemies.js
+++ b/docs/js/update_enemies.js
@@ -154,7 +154,8 @@ function updateEnemies(g, dt, dtF, bossAlive) {
                         g.shakeTimer = Math.max(g.shakeTimer, 10);
                         // Warning text
                         const bp = project(e.x, e.z - g.cameraZ);
-                        addScorePopup('🐘 STOMP WAVE!', bp.x, bp.y - 40, 0xff4400);
+                        const warningText = e.isElephantBoss ? '🔥 LAVA BREATH!' : '🔥 FLAME BREATH!';
+                        addScorePopup(warningText, bp.x, bp.y - 40, 0xff4400);
                     } else if (skill === 1) {
                         // --- SUMMON MINIONS: spawn a small squad of enemies ---
                         if (e.megaSummonCount < 3 + e.megaLevel) {


### PR DESCRIPTION
## Summary
- Replace the incorrect `STOMP WAVE!` popup on the mega boss projectile-fan skill.
- Show `FLAME BREATH!` for dragon mega bosses and `LAVA BREATH!` for elephant mega bosses.

## Why
The skill branch launches flame/lava projectiles, but the warning text described a ground-slam style attack. The wrong cue can make players dodge the wrong pattern.

## Test plan
- `for f in docs/js/*.js; do node --check "$f" || exit 1; done`
- `git diff --check`

Closes #79
