### PR TITLE
Bump JS cache-buster v=28 -> v=29 and CSS v=15 -> v=16, Closes #80

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
 <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="stylesheet" href="style.css?v=15">
+<link rel="stylesheet" href="style.css?v=16">
 <style>
 /* p5.js canvas sits behind all overlays.
    Use "body > canvas" to target only the p5 canvas (direct child of body),
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=28"></script>
-<script src="js/config.js?v=28"></script>
-<script src="js/i18n.js?v=28"></script>
-<script src="js/globals.js?v=28"></script>
-<script src="js/audio.js?v=28"></script>
-<script src="js/core.js?v=28"></script>
-<script src="js/helpers.js?v=28"></script>
-<script src="js/spawn.js?v=28"></script>
-<script src="js/combat.js?v=28"></script>
-<script src="js/draw.js?v=28"></script>
-<script src="js/hud.js?v=28"></script>
-<script src="js/update_timers.js?v=28"></script>
-<script src="js/update_collision.js?v=28"></script>
-<script src="js/update_enemies.js?v=28"></script>
-<script src="js/update_world.js?v=28"></script>
-<script src="js/update_effects.js?v=28"></script>
-<script src="js/update.js?v=28"></script>
-<script src="js/render.js?v=28"></script>
-<script src="js/achievements.js?v=28"></script>
-<script src="js/shop.js?v=28"></script>
-<script src="js/leaderboard.js?v=28"></script>
-<script src="js/input.js?v=28"></script>
-<script src="js/ui.js?v=28"></script>
-<script src="js/tutorial.js?v=28"></script>
-<script src="js/main.js?v=28"></script>
+<script src="js/crypto.js?v=29"></script>
+<script src="js/config.js?v=29"></script>
+<script src="js/i18n.js?v=29"></script>
+<script src="js/globals.js?v=29"></script>
+<script src="js/audio.js?v=29"></script>
+<script src="js/core.js?v=29"></script>
+<script src="js/helpers.js?v=29"></script>
+<script src="js/spawn.js?v=29"></script>
+<script src="js/combat.js?v=29"></script>
+<script src="js/draw.js?v=29"></script>
+<script src="js/hud.js?v=29"></script>
+<script src="js/update_timers.js?v=29"></script>
+<script src="js/update_collision.js?v=29"></script>
+<script src="js/update_enemies.js?v=29"></script>
+<script src="js/update_world.js?v=29"></script>
+<script src="js/update_effects.js?v=29"></script>
+<script src="js/update.js?v=29"></script>
+<script src="js/render.js?v=29"></script>
+<script src="js/achievements.js?v=29"></script>
+<script src="js/shop.js?v=29"></script>
+<script src="js/leaderboard.js?v=29"></script>
+<script src="js/input.js?v=29"></script>
+<script src="js/ui.js?v=29"></script>
+<script src="js/tutorial.js?v=29"></script>
+<script src="js/main.js?v=29"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
`docs/index.html` last bumped its JS query string at f0920c3 (`v=28`). Since then 17+ commits have landed under `docs/js/` — including #16, #35, #55, #57, #59, #64, #68 from the recent merge batch, plus the four follow-up fixes #70/#72/#74/#76. `docs/style.css?v=15` is similarly stale (#16 and the in-flight #61 added new selectors).

This PR bumps every `?v=28` script tag to `?v=29` and `style.css?v=15` to `?v=16` so returning visitors fetch the new bundle instead of running cached pre-fix code against the new HTML.

## Test plan
- [ ] Open the page, hard-refresh once, confirm DevTools shows JS files served with `?v=29` and CSS with `?v=16`.
- [ ] Soft-refresh; confirm the cached `v=29` files are reused (304 / from cache) — no version downgrade.
- [ ] Verify recent fixes are visible (HUD reads "Shotgun", clicking Start opens level-select once, weapon badge shows).

Closes #80