### PR TITLE
Align Iron Fortress with max armor level

### DIFF
--- a/docs/js/achievements.js
+++ b/docs/js/achievements.js
@@ -174,9 +174,13 @@ const ACHIEVEMENTS = {
     },
     iron_fortress: {
         name: 'Iron Fortress', icon: 'shield', category: 'arsenal',
-        desc: ['Max armor (Lv3)'],
+        desc: ['Max armor'],
         tiers: 1, goals: [1],
-        check: () => (playerData.armor || 0) >= 3 ? 1 : 0,
+        check: () => {
+            const armorDef = TALENT_DEFS.find(d => d.id === 'armor');
+            const maxArmorLevel = armorDef ? armorDef.maxLevel : 6;
+            return (playerData.armor || 0) >= maxArmorLevel ? 1 : 0;
+        },
         rewards: [{ gems: 2 }],
     },
 


### PR DESCRIPTION
## Summary
- Update `Iron Fortress` so it unlocks only at the configured Armor max level.
- Remove the stale `Lv3` wording from the achievement description.

## Why
Armor currently has six talent levels, but the achievement still treated level 3 as max armor.

## Test plan
- `for f in docs/js/*.js; do node --check "$f" || exit 1; done`
- `git diff --check`

Closes #85
