### PR TITLE
Wire shop BACK button to closeShop() via inline onclick, Closes #89

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -238,7 +238,7 @@ body > canvas {
                 <div class="talent-hint" style="margin-top:min(14px,2vh)"><svg viewBox="0 0 14 14" width="13" height="13" style="vertical-align:-2px"><polygon points="7,1 13,6 7,13 1,6" fill="#8822bb"/><polygon points="7,1 13,6 7,7 1,6" fill="#cc44ff"/><polygon points="5,3 9,3 7,1" fill="#ee88ff"/></svg> <span data-i18n="shop.talent.hint">宝石由 Boss 随机掉落，用于永久提升角色属性</span></div>
             </div>
         </div>
-        <button class="btn btn-back" id="shopBackBtn" data-i18n="shop.back">BACK</button>
+        <button class="btn btn-back" id="shopBackBtn" onclick="closeShop()" data-i18n="shop.back">BACK</button>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
`#shopBackBtn` had no `onclick` and no JS-side listener after #72 dropped the duplicate `addEventListener`. The cleanup assumed both shop buttons used the inline-onclick pattern, but only `#shopBtn` actually did. Result: clicking **BACK** inside the shop did nothing.

This PR adds `onclick="closeShop()"` to the BACK button so it matches the pattern used by every other modal-close button in `index.html`.

## Test plan
- [ ] Open shop from main menu → click **BACK** → shop closes.
- [ ] Open shop, switch to a non-default tab, click BACK → shop closes from any tab.
- [ ] Buy something, click BACK → returns to main menu and currency display refreshes.

Closes #89