### PR TITLE
Drop sprite-count debug log from _buildSpriteFrames, Closes #91

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -105,7 +105,6 @@ function _buildSpriteFrames() {
         tutorialBossFrames.push({ img: _p5TutorialBossImg, sx: i * TUTORIAL_BOSS_FRAME_SIZE, sy: 0, sw: TUTORIAL_BOSS_FRAME_SIZE, sh: TUTORIAL_BOSS_FRAME_SIZE });
     }
     monsterSpritesLoaded = true;
-    console.log('Sprites loaded: Patrick', normalMonsterFrames.length, 'XiaoNaiLong', xiaoNaiLongFrames.length, 'Boss', bossFrames.length);
 }
 
 function draw() {


### PR DESCRIPTION
## Summary
`_buildSpriteFrames()` ended with a `console.log` that reported sprite counts on every page load. Those counts come from compile-time constants in `config.js` — the line never reports anything new, only noise.

`audio.js` still logs real load failures, which is intentional and stays.

## Test plan
- [ ] Reload the page, open DevTools console: no "Sprites loaded: …" line.
- [ ] Audio failure path still logs "Audio: failed to load: …" if a sound 404s.

Closes #91