### PR TITLE
Drop unused startBtn DOM reference in globals.js, Closes #94

### DIFF
--- a/docs/js/globals.js
+++ b/docs/js/globals.js
@@ -47,7 +47,6 @@ const keys = {};
 
 // DOM references
 const overlay = document.getElementById('overlay');
-const startBtn = document.getElementById('startBtn');
 
 // Snapshot of the pristine main-menu markup. Captured at page load (before
 // any user interaction or dynamic writes) so that returning to the menu

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -216,7 +216,7 @@ function triggerLevelComplete() {
     `;
     if (isL2Clear) {
         const prev = playerData.l2HighScore || { score: 0, wave: 0 };
-        if (g.score > prev.score) {
+        if (isBetterRunRecord(g.score, g.wave - 1, prev)) {
             playerData.l2HighScore = { score: g.score, wave: g.wave - 1 };
             savePlayerData(playerData);
         }
@@ -584,11 +584,17 @@ function getHighScore() {
 
 function saveHighScore(score, wave) {
     const prev = getHighScore();
-    if (score > prev.score) {
+    if (isBetterRunRecord(score, wave, prev)) {
         _signedSave('bridgeAssault_highScore', { score, wave });
         return true;
     }
     return false;
+}
+
+function isBetterRunRecord(score, wave, prev) {
+    const prevScore = prev && prev.score ? prev.score : 0;
+    const prevWave = prev && prev.wave ? prev.wave : 0;
+    return score > prevScore || (score === prevScore && wave > prevWave);
 }
 
 // ============================================================
@@ -685,7 +691,7 @@ function showGameOver() {
     let isNewRecord;
     if (currentLvl === 2) {
         const prev = playerData.l2HighScore || { score: 0, wave: 0 };
-        if (game.score > prev.score) {
+        if (isBetterRunRecord(game.score, game.wave, prev)) {
             playerData.l2HighScore = { score: game.score, wave: game.wave };
             savePlayerData(playerData);
             isNewRecord = true;


### PR DESCRIPTION
## Summary
`globals.js` declared `const startBtn = document.getElementById('startBtn')` but no caller ever read it. `#startBtn` runs `showLevelSelect()` directly via the inline onclick in `index.html` (see #75 / #76). The global lookup is dead code.

## Test plan
- [ ] Reload the page, click Start: level-select still opens.
- [ ] grep for `\bstartBtn\b` in `docs/js/` returns no remaining usages.

Closes #94