### PR TITLE
Complete levels when final boss wave clears

### DIFF
--- a/docs/js/update_effects.js
+++ b/docs/js/update_effects.js
@@ -182,11 +182,10 @@ function updateEffects(g, dt, dtF) {
     });
 
     // Level clear detection
-    if (g.currentLevel === 1 && g.wave > MAX_WAVES_LEVEL1 && !g.levelCompleted) {
-        g.levelCompleted = true;
-        triggerLevelComplete();
-    }
-    if (g.currentLevel === 2 && g.wave > MAX_WAVES_LEVEL2 && !g.levelCompleted) {
+    const maxWave = g.currentLevel === 2 ? MAX_WAVES_LEVEL2 : MAX_WAVES_LEVEL1;
+    const finalBossAlive = g.enemies.some(e => e.alive && e.isBoss);
+    if ((g.currentLevel === 1 || g.currentLevel === 2) &&
+        g.wave >= maxWave && !finalBossAlive && !g.levelCompleted) {
         g.levelCompleted = true;
         triggerLevelComplete();
     }


### PR DESCRIPTION
## Summary
- Complete Level I/II once the configured final wave is reached and no boss remains alive.
- Avoid waiting for wave 67/89 before showing the completion screen.

## Why
The old `wave > max` check required one more wave increment after the final wave, which could drift records and allow extra content past the level cap.

## Test plan
- `for f in docs/js/*.js; do node --check "$f" || exit 1; done`
- `git diff --check`

Closes #97
