### PR TITLE
Remove dead #skillBtn DOM lookups across input/ui/tutorial, Closes #96

### DIFF
--- a/docs/js/input.js
+++ b/docs/js/input.js
@@ -48,14 +48,6 @@ function setupInput() {
             else if (game.state === 'paused') { resumeGame(); }
         }
     });
-
-    const skillBtn = document.getElementById('skillBtn');
-    if (skillBtn) {
-        skillBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            activateSkillWeapon();
-        });
-    }
 }
 
 // ============================================================

--- a/docs/js/tutorial.js
+++ b/docs/js/tutorial.js
@@ -295,8 +295,6 @@ function completeTutorial() {
     savePlayerData(playerData);
     const slotsDiv = document.getElementById('weaponSlots');
     if (slotsDiv) slotsDiv.style.display = 'none';
-    const skillBtn = document.getElementById('skillBtn');
-    if (skillBtn) skillBtn.style.display = 'none';
     overlay.classList.remove('hidden');
     renderTutorialCompleteOverlay();
     game = null;

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -250,8 +250,6 @@ function startGame(level) {
     game.skillCooldown = 0;
     spawnEnemyWave();
     overlay.classList.add('hidden');
-    const skillBtn = document.getElementById('skillBtn');
-    if (skillBtn) skillBtn.style.display = 'none';
     initWeaponSlots();
     updateWeaponSlots();
     _skyBgW = 0; _skyBgH = 0; _skyBgLevel = 0;
@@ -707,8 +705,6 @@ function showGameOver() {
     document.getElementById('midShopOverlay').classList.add('hidden');
     const slotsDiv = document.getElementById('weaponSlots');
     if (slotsDiv) slotsDiv.style.display = 'none';
-    const skillBtn = document.getElementById('skillBtn');
-    if (skillBtn) skillBtn.style.display = 'none';
     overlay.innerHTML = `
         <h1>${T('gameover.title')}</h1>
         <div id="scoreDisplay">${T('gameover.score')}</div>


### PR DESCRIPTION
## Summary
`#skillBtn` is not defined in `docs/index.html` (`grep skillBtn docs/index.html` → no matches). Every `getElementById('skillBtn')` call across `input.js`, `ui.js` (twice), and `tutorial.js` therefore returned null — guarded by `if (skillBtn)` so nothing crashed, but the lookups and the `addEventListener` registration in `input.js` did nothing at runtime.

The skill is fully reachable today via:
- Spacebar (`input.js:18-22`) → `activateSkillWeapon()`
- Hot keys 1 / 2 → invincibility / stimulant
- The weapon-slot DOM panel (`ui.js`) → `activateWeaponByKey(key)`

## Test plan
- [ ] Start any level: no console errors, weapon slots panel still appears.
- [ ] Press spacebar mid-run: still activates the temp weapon.
- [ ] Click a weapon slot in the HUD: still activates the corresponding charge.
- [ ] `grep skillBtn docs/` returns no matches.

Closes #96