### PR TITLE
Preserve saves across data version bumps

### DIFF
--- a/docs/js/globals.js
+++ b/docs/js/globals.js
@@ -63,12 +63,16 @@ const DATA_VERSION = 'v2';
 (function checkDataVersion() {
     const stored = localStorage.getItem('bridgeAssault_dataVersion');
     if (stored !== DATA_VERSION) {
-        Object.keys(localStorage)
-            .filter(k => k.startsWith('bridgeAssault_'))
-            .forEach(k => localStorage.removeItem(k));
         localStorage.setItem('bridgeAssault_dataVersion', DATA_VERSION);
     }
 })();
+
+function resetBridgeAssaultSaveData() {
+    Object.keys(localStorage)
+        .filter(k => k.startsWith('bridgeAssault_'))
+        .forEach(k => localStorage.removeItem(k));
+    localStorage.setItem('bridgeAssault_dataVersion', DATA_VERSION);
+}
 
 function loadPlayerData() {
     try {


### PR DESCRIPTION
## Summary
- Stop deleting every `bridgeAssault_` localStorage key when `DATA_VERSION` changes.
- Keep the version marker update so the current schema is still recorded.
- Add `resetBridgeAssaultSaveData()` for intentional save clearing.

## Why
The code already initializes missing fields and supports compatible legacy save shapes. Clearing all local progress on every data-version change makes routine updates feel like save corruption.

## Test plan
- `for f in docs/js/*.js; do node --check "$f" || exit 1; done`
- `git diff --check`

Closes #42
