### PR TITLE
Disconnect BGM gain node in stopBGM to prevent audio-graph leak, Closes #103

### DIFF
--- a/docs/js/audio.js
+++ b/docs/js/audio.js
@@ -119,6 +119,13 @@ function stopBGM() {
         _bgmSource = null;
         _bgmPlaying = false;
     }
+    // Disconnect the gain node so the previous BGM track's audio graph
+    // can be garbage-collected. Without this, every level transition
+    // orphans a GainNode that stays connected to audioCtx.destination.
+    if (_bgmGain) {
+        try { _bgmGain.disconnect(); } catch (_) {}
+        _bgmGain = null;
+    }
 }
 
 function setBGMVolume(vol) {


### PR DESCRIPTION
## Summary
`playBGM` creates a new `GainNode` and connects it to `audioCtx.destination` every call. `stopBGM` was only stopping the source — the gain node was left connected. The next `playBGM` then overwrites the global `_bgmGain`, so the previous gain node was orphaned but still attached to `destination`, and the browser keeps it alive.

Each L1 → menu → L2 cycle leaks one `GainNode`. Negligible per cycle, but it accumulates and shows up in DevTools' audio-graph state.

## Fix
```js
if (_bgmGain) {
    try { _bgmGain.disconnect(); } catch (_) {}
    _bgmGain = null;
}
```
`setBGMVolume` already null-guards (`if (_bgmGain)`), so clearing the reference doesn't break runtime volume changes.

## Test plan
- [ ] Start L1, return to menu, start L2, return to menu, repeat 5 times. BGM still plays correctly each time, no audio glitches.
- [ ] Inspect `audioCtx.destination` connection count in DevTools after several cycles — does not grow unboundedly.

Closes #103