### PR TITLE
Disconnect BGM gain node in stopBGM

### DIFF
--- a/docs/js/audio.js
+++ b/docs/js/audio.js
@@ -119,6 +119,13 @@ function stopBGM() {
         _bgmSource = null;
         _bgmPlaying = false;
     }
+    // Disconnect the gain node so the previous BGM track's audio graph
+    // can be garbage-collected. Without this, every level transition
+    // orphans a GainNode that stays connected to audioCtx.destination.
+    if (_bgmGain) {
+        try { _bgmGain.disconnect(); } catch (_) {}
+        _bgmGain = null;
+    }
 }
 
 function setBGMVolume(vol) {


### PR DESCRIPTION
## Summary
- Disconnect and clear `_bgmGain` in `stopBGM()`.
- Prevent old BGM gain nodes from staying connected after level/menu transitions.

## Why
`playBGM()` creates a new `GainNode` each time. Stopping only the source leaves the previous gain node connected to `audioCtx.destination`, which accumulates across long sessions.

## Test plan
- `for f in docs/js/*.js; do node --check "$f" || exit 1; done`
- `git diff --check origin/main...HEAD`

Closes #103
