### PR TITLE
Disconnect one-shot sound effect nodes

### DIFF
--- a/docs/js/audio.js
+++ b/docs/js/audio.js
@@ -148,6 +148,10 @@ function playSound(type) {
             gain.gain.value = (def.vol || 0.5) * _audioVolume;
             source.connect(gain);
             gain.connect(audioCtx.destination);
+            source.onended = () => {
+                try { source.disconnect(); } catch (_) {}
+                try { gain.disconnect(); } catch (_) {}
+            };
             source.start(0);
             return;
         } catch (_) { /* fall through to synth */ }


### PR DESCRIPTION
## Summary\n- disconnect buffered sound effect source/gain nodes after playback ends\n- keep the synthesized fallback path unchanged\n\n## Why\nRepeated short effects create one-shot audio graph nodes. Without cleanup, finished effects can leave gain nodes connected to the audio destination during long sessions.\n\n## Test plan\n- for f in docs/js/*.js; do node --check "" || exit 1; done\n- git diff --check\n\nCloses #106