### PR TITLE
Drop wave_start sound effect, Closes #108

### DIFF
--- a/docs/js/update_world.js
+++ b/docs/js/update_world.js
@@ -133,7 +133,6 @@ function updateWorld(g, dt, dtF, bossAlive) {
             else spawnBoss(g.nextWaveZ - 80);
         }
         g.waveBanner = { wave: g.wave, timer: 0, maxTimer: CONFIG.WAVE_BANNER_DURATION };
-        playSound('wave_start');
     }
     if (g.cameraZ + CONFIG.SPAWN_DISTANCE > g.nextGateZ) spawnGate();
 


### PR DESCRIPTION
## Summary
The wave-start buzz fired every wave transition (~30s during normal play) and was reported as unpleasant. It adds no information beyond the wave banner already shown visually.

This PR removes the single `playSound('wave_start')` call in `update_world.js:136`. The audio asset and synth fallback stay registered in `audio.js` so a future gentler cue can replace it without an asset migration.

## Test plan
- [ ] Start any level, survive into wave 2-5: no wave-start sound, banner still shows.
- [ ] Other sounds (shoot, hit, gate, explosion, BGM) still play correctly.

Closes #108