### PR TITLE
Clear movement keys when focus is lost

### DIFF
--- a/docs/js/input.js
+++ b/docs/js/input.js
@@ -3,6 +3,10 @@
 // ============================================================
 
 function setupInput() {
+    const clearKeys = () => {
+        Object.keys(keys).forEach(k => { keys[k] = false; });
+    };
+
     document.addEventListener('keydown', (e) => {
         keys[e.key] = true;
         if (e.key === 'Escape' || e.key === 'p' || e.key === 'P') {
@@ -31,6 +35,10 @@ function setupInput() {
         }
     });
     document.addEventListener('keyup', (e) => { keys[e.key] = false; });
+    window.addEventListener('blur', clearKeys);
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) clearKeys();
+    });
 
     // Pause button
     const pauseBtn = document.getElementById('pauseBtn');


### PR DESCRIPTION
## Summary\n- clear tracked keyboard state when the window blurs\n- also clear tracked keys when the page becomes hidden\n\n## Why\nIf focus changes while a movement key is held, the browser can miss the matching keyup event. Resetting the key map prevents stale movement input when the player returns to the game.\n\n## Test plan\n- for f in docs/js/*.js; do node --check "" || exit 1; done\n- git diff --check\n\nCloses #110