### PR TITLE
Declutter top-left weapon panel

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
 <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="stylesheet" href="style.css?v=16">
+<link rel="stylesheet" href="style.css?v=17">
 <style>
 /* p5.js canvas sits behind all overlays.
    Use "body > canvas" to target only the p5 canvas (direct child of body),
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=29"></script>
-<script src="js/config.js?v=29"></script>
-<script src="js/i18n.js?v=29"></script>
-<script src="js/globals.js?v=29"></script>
-<script src="js/audio.js?v=29"></script>
-<script src="js/core.js?v=29"></script>
-<script src="js/helpers.js?v=29"></script>
-<script src="js/spawn.js?v=29"></script>
-<script src="js/combat.js?v=29"></script>
-<script src="js/draw.js?v=29"></script>
-<script src="js/hud.js?v=29"></script>
-<script src="js/update_timers.js?v=29"></script>
-<script src="js/update_collision.js?v=29"></script>
-<script src="js/update_enemies.js?v=29"></script>
-<script src="js/update_world.js?v=29"></script>
-<script src="js/update_effects.js?v=29"></script>
-<script src="js/update.js?v=29"></script>
-<script src="js/render.js?v=29"></script>
-<script src="js/achievements.js?v=29"></script>
-<script src="js/shop.js?v=29"></script>
-<script src="js/leaderboard.js?v=29"></script>
-<script src="js/input.js?v=29"></script>
-<script src="js/ui.js?v=29"></script>
-<script src="js/tutorial.js?v=29"></script>
-<script src="js/main.js?v=29"></script>
+<script src="js/crypto.js?v=30"></script>
+<script src="js/config.js?v=30"></script>
+<script src="js/i18n.js?v=30"></script>
+<script src="js/globals.js?v=30"></script>
+<script src="js/audio.js?v=30"></script>
+<script src="js/core.js?v=30"></script>
+<script src="js/helpers.js?v=30"></script>
+<script src="js/spawn.js?v=30"></script>
+<script src="js/combat.js?v=30"></script>
+<script src="js/draw.js?v=30"></script>
+<script src="js/hud.js?v=30"></script>
+<script src="js/update_timers.js?v=30"></script>
+<script src="js/update_collision.js?v=30"></script>
+<script src="js/update_enemies.js?v=30"></script>
+<script src="js/update_world.js?v=30"></script>
+<script src="js/update_effects.js?v=30"></script>
+<script src="js/update.js?v=30"></script>
+<script src="js/render.js?v=30"></script>
+<script src="js/achievements.js?v=30"></script>
+<script src="js/shop.js?v=30"></script>
+<script src="js/leaderboard.js?v=30"></script>
+<script src="js/input.js?v=30"></script>
+<script src="js/ui.js?v=30"></script>
+<script src="js/tutorial.js?v=30"></script>
+<script src="js/main.js?v=30"></script>
 </body>
 </html>

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -383,26 +383,11 @@ function initWeaponSlots() {
         </div>
     `;
     slotsDiv.appendChild(currentBadge);
-    const orderedTempWeapons = ['shotgun', 'laser', 'rocket'];
-    const tempWeaponDisplayNames = {
-        shotgun: 'Shotgun',
-        laser: 'Laser',
-        rocket: 'Rocket',
-    };
-    for (const key of orderedTempWeapons) {
-        const w = SHOP_WEAPONS[key];
-        if (!w) continue;
-        const slot = document.createElement('div');
-        slot.className = 'wslot';
-        slot.dataset.weapon = key;
-        slot.style.setProperty('--wcolor', w.color);
-        slot.innerHTML = `
-            <div class="wslot-icon">${w.icon}</div>
-            <div class="wslot-level" style="font-size:10px;color:rgba(255,255,255,0.9)">${tempWeaponDisplayNames[key] || key}</div>
-            <div class="wslot-equipped" style="font-size:9px;color:#ffd700;min-height:12px"></div>
-        `;
-        slotsDiv.appendChild(slot);
-    }
+    // Temp-weapon slots (shotgun / laser / rocket) used to live here but
+    // were passive — non-interactive, and the current-weapon badge above
+    // already surfaces whichever temp weapon is firing. Skill slots below
+    // are the only entries the player can act on, so the panel only
+    // renders those now.
     for (const key of ['invincibility', 'stimulant']) {
         const sw = SHOP_WEAPONS[key];
         const slot = document.createElement('div');
@@ -498,13 +483,12 @@ function updateWeaponSlots() {
     const slotsDiv = document.getElementById('weaponSlots');
     if (!slotsDiv || slotsDiv.style.display === 'none') return;
     updateCurrentWeaponBadge();
-    const levels = playerData.weaponLevels || {};
     const charges = playerData.weaponCharges || {};
     slotsDiv.querySelectorAll('.wslot').forEach(slot => {
         const key = slot.dataset.weapon;
         const w = SHOP_WEAPONS[key];
         if (!w) return;
-        if (key === 'invincibility' || key === 'stimulant') {
+        {
             const count = charges[key] || 0;
             const isActive = key === 'invincibility' ? g.shieldActive : g.stimulantActive;
             const isOnCooldown = key === 'invincibility' ? (g.skillCooldown > 0) : (g.stimulantCooldown > 0);
@@ -534,25 +518,6 @@ function updateWeaponSlots() {
             if (isActive) { slot.classList.add('wslot-active'); slot.style.borderColor = '#ffd700'; }
             else if (count <= 0) { slot.classList.add('wslot-empty'); slot.style.borderColor = 'rgba(255,255,255,0.08)'; }
             else if (isOnCooldown) { slot.classList.add('wslot-dim'); slot.style.borderColor = 'rgba(255,255,255,0.12)'; }
-            else { slot.classList.add('wslot-ready'); slot.style.borderColor = w.color; }
-        } else {
-            const level = levels[key] || 0;
-            const isGateActive = g.weapon === key && g.weaponTimer > 0;
-            const levelEl = slot.querySelector('.wslot-level');
-            const tempWeaponDisplayNames = {
-                shotgun: 'Shotgun',
-                laser: 'Laser',
-                rocket: 'Rocket',
-            };
-            if (levelEl) {
-                levelEl.textContent = tempWeaponDisplayNames[key] || key;
-                levelEl.style.color = level > 0 ? w.color : 'rgba(255,255,255,0.8)';
-            }
-            const equippedEl = slot.querySelector('.wslot-equipped');
-            if (equippedEl) equippedEl.textContent = isGateActive ? 'TEMP' : '';
-            slot.className = 'wslot';
-            if (isGateActive) { slot.classList.add('wslot-active'); slot.style.borderColor = '#ffd700'; }
-            else if (level <= 0) { slot.classList.add('wslot-empty'); slot.style.borderColor = 'rgba(255,255,255,0.08)'; }
             else { slot.classList.add('wslot-ready'); slot.style.borderColor = w.color; }
         }
     });

--- a/docs/style.css
+++ b/docs/style.css
@@ -1017,9 +1017,15 @@ body::after {
     font-family: 'Courier New', monospace;
     font-size: min(10px, 2vw);
     font-weight: bold;
-    color: rgba(255,255,255,0.3);
+    color: rgba(255,255,255,0.82);
     line-height: 1;
     text-align: center;
+    background: rgba(0,0,0,0.45);
+    border: 1px solid rgba(255,255,255,0.18);
+    border-radius: 4px;
+    padding: 1px 5px;
+    align-self: center;
+    letter-spacing: 0.5px;
 }
 
 .wslot-icon {


### PR DESCRIPTION
## Summary\n- remove passive shotgun/laser/rocket tiles from the in-game weapon panel\n- keep the live current-weapon badge plus the two actionable skill slots\n- make skill hotkey badges more readable and bump static cache versions\n\n## Why\nThe removed temp-weapon tiles looked clickable but had no click handler, while their live state was already represented by the current-weapon badge. Keeping only actionable skill slots makes the HUD easier to scan during play.\n\n## Test plan\n- for f in docs/js/*.js; do node --check "" || exit 1; done\n- git diff --check origin/main...HEAD\n\nCloses #112