### PR TITLE
Clamp initial touch input to road bounds

### DIFF
--- a/docs/js/input.js
+++ b/docs/js/input.js
@@ -81,7 +81,7 @@ function touchMoved() {
 
 function touchStarted() {
     if (game && game.state === 'playing' && touches.length > 0) {
-        game.inputX = _getWorldX(touches[0].x);
+        game.inputX = Math.max(-CONFIG.ROAD_HALF_WIDTH, Math.min(CONFIG.ROAD_HALF_WIDTH, _getWorldX(touches[0].x)));
     }
     return false;
 }


### PR DESCRIPTION
## Summary\n- clamp touch-start input targets to the road bounds\n- keep touch move and mouse movement behavior unchanged\n\n## Why\nThe first touch frame could set an out-of-road input target before movement clamping caught up. Matching the existing touch-move clamp removes a small edge-case snap/jitter near screen edges.\n\n## Test plan\n- for f in docs/js/*.js; do node --check "" || exit 1; done\n- git diff --check\n\nCloses #115