### PR TITLE
Disable looping BGM in startGame, Closes #117

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=30"></script>
-<script src="js/config.js?v=30"></script>
-<script src="js/i18n.js?v=30"></script>
-<script src="js/globals.js?v=30"></script>
-<script src="js/audio.js?v=30"></script>
-<script src="js/core.js?v=30"></script>
-<script src="js/helpers.js?v=30"></script>
-<script src="js/spawn.js?v=30"></script>
-<script src="js/combat.js?v=30"></script>
-<script src="js/draw.js?v=30"></script>
-<script src="js/hud.js?v=30"></script>
-<script src="js/update_timers.js?v=30"></script>
-<script src="js/update_collision.js?v=30"></script>
-<script src="js/update_enemies.js?v=30"></script>
-<script src="js/update_world.js?v=30"></script>
-<script src="js/update_effects.js?v=30"></script>
-<script src="js/update.js?v=30"></script>
-<script src="js/render.js?v=30"></script>
-<script src="js/achievements.js?v=30"></script>
-<script src="js/shop.js?v=30"></script>
-<script src="js/leaderboard.js?v=30"></script>
-<script src="js/input.js?v=30"></script>
-<script src="js/ui.js?v=30"></script>
-<script src="js/tutorial.js?v=30"></script>
-<script src="js/main.js?v=30"></script>
+<script src="js/crypto.js?v=31"></script>
+<script src="js/config.js?v=31"></script>
+<script src="js/i18n.js?v=31"></script>
+<script src="js/globals.js?v=31"></script>
+<script src="js/audio.js?v=31"></script>
+<script src="js/core.js?v=31"></script>
+<script src="js/helpers.js?v=31"></script>
+<script src="js/spawn.js?v=31"></script>
+<script src="js/combat.js?v=31"></script>
+<script src="js/draw.js?v=31"></script>
+<script src="js/hud.js?v=31"></script>
+<script src="js/update_timers.js?v=31"></script>
+<script src="js/update_collision.js?v=31"></script>
+<script src="js/update_enemies.js?v=31"></script>
+<script src="js/update_world.js?v=31"></script>
+<script src="js/update_effects.js?v=31"></script>
+<script src="js/update.js?v=31"></script>
+<script src="js/render.js?v=31"></script>
+<script src="js/achievements.js?v=31"></script>
+<script src="js/shop.js?v=31"></script>
+<script src="js/leaderboard.js?v=31"></script>
+<script src="js/input.js?v=31"></script>
+<script src="js/ui.js?v=31"></script>
+<script src="js/tutorial.js?v=31"></script>
+<script src="js/main.js?v=31"></script>
 </body>
 </html>

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -254,8 +254,10 @@ function startGame(level) {
     updateWeaponSlots();
     _skyBgW = 0; _skyBgH = 0; _skyBgLevel = 0;
     resetAchTempFlags();
-    // Start BGM matching current level (tutorial uses L1 track)
-    playBGM(game.currentLevel);
+    // BGM disabled: the looping track was reported as a sustained low hum.
+    // The playBGM / stopBGM machinery is kept intact so a gentler track can
+    // be re-enabled by uncommenting this call.
+    // playBGM(game.currentLevel);
 }
 
 function startTutorial() {


### PR DESCRIPTION
## Summary
User reported a sustained low hum starting the moment a level loads. `wave_start` was removed in #109, leaving the BGM loop as the only sound that fires immediately on game entry and is sustained.

This PR comments out the single `playBGM(game.currentLevel)` call at the bottom of `startGame`. Neither L1 / L2 / tutorial start any background music. The `playBGM` / `stopBGM` machinery and the BGM mp3 assets stay in place — re-enabling later is a one-line change.

Cache-buster bumped (`?v=30` → `?v=31`) so returning visitors get the silent build without a hard refresh.

(This replaces #118, which had a stale-base conflict after #113 / #116 landed in parallel.)

## Test plan
- [ ] Hard-refresh, start L1: silent at game entry, no hum.
- [ ] Same on L2 and on the tutorial.
- [ ] Other sounds still play (shoot / hit / explosion / gate_good / gate_bad / weapon_pickup).

Closes #117