### PR TITLE
Re-enable BGM in startGame (buzz wasn't from music)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=31"></script>
-<script src="js/config.js?v=31"></script>
-<script src="js/i18n.js?v=31"></script>
-<script src="js/globals.js?v=31"></script>
-<script src="js/audio.js?v=31"></script>
-<script src="js/core.js?v=31"></script>
-<script src="js/helpers.js?v=31"></script>
-<script src="js/spawn.js?v=31"></script>
-<script src="js/combat.js?v=31"></script>
-<script src="js/draw.js?v=31"></script>
-<script src="js/hud.js?v=31"></script>
-<script src="js/update_timers.js?v=31"></script>
-<script src="js/update_collision.js?v=31"></script>
-<script src="js/update_enemies.js?v=31"></script>
-<script src="js/update_world.js?v=31"></script>
-<script src="js/update_effects.js?v=31"></script>
-<script src="js/update.js?v=31"></script>
-<script src="js/render.js?v=31"></script>
-<script src="js/achievements.js?v=31"></script>
-<script src="js/shop.js?v=31"></script>
-<script src="js/leaderboard.js?v=31"></script>
-<script src="js/input.js?v=31"></script>
-<script src="js/ui.js?v=31"></script>
-<script src="js/tutorial.js?v=31"></script>
-<script src="js/main.js?v=31"></script>
+<script src="js/crypto.js?v=32"></script>
+<script src="js/config.js?v=32"></script>
+<script src="js/i18n.js?v=32"></script>
+<script src="js/globals.js?v=32"></script>
+<script src="js/audio.js?v=32"></script>
+<script src="js/core.js?v=32"></script>
+<script src="js/helpers.js?v=32"></script>
+<script src="js/spawn.js?v=32"></script>
+<script src="js/combat.js?v=32"></script>
+<script src="js/draw.js?v=32"></script>
+<script src="js/hud.js?v=32"></script>
+<script src="js/update_timers.js?v=32"></script>
+<script src="js/update_collision.js?v=32"></script>
+<script src="js/update_enemies.js?v=32"></script>
+<script src="js/update_world.js?v=32"></script>
+<script src="js/update_effects.js?v=32"></script>
+<script src="js/update.js?v=32"></script>
+<script src="js/render.js?v=32"></script>
+<script src="js/achievements.js?v=32"></script>
+<script src="js/shop.js?v=32"></script>
+<script src="js/leaderboard.js?v=32"></script>
+<script src="js/input.js?v=32"></script>
+<script src="js/ui.js?v=32"></script>
+<script src="js/tutorial.js?v=32"></script>
+<script src="js/main.js?v=32"></script>
 </body>
 </html>

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -254,10 +254,8 @@ function startGame(level) {
     updateWeaponSlots();
     _skyBgW = 0; _skyBgH = 0; _skyBgLevel = 0;
     resetAchTempFlags();
-    // BGM disabled: the looping track was reported as a sustained low hum.
-    // The playBGM / stopBGM machinery is kept intact so a gentler track can
-    // be re-enabled by uncommenting this call.
-    // playBGM(game.currentLevel);
+    // Start BGM matching current level (tutorial uses L1 track)
+    playBGM(game.currentLevel);
 }
 
 function startTutorial() {


### PR DESCRIPTION
## Summary
#119 muted BGM on the assumption that it was the source of the reported sustained hum, but the user confirmed afterwards that BGM had nothing to do with the buzz — the noise was still present without music. Restore the `playBGM(game.currentLevel)` call so background music returns. The actual buzz source is being investigated separately.

Cache-buster bumped `v=31` → `v=32` so the silent build is replaced for returning visitors.

Re-opens #117 in spirit (the hum is still unfixed) but stops the regression of having no music at all.

## Test plan
- [ ] Hard-refresh, start L1 / L2 / tutorial: BGM track plays again on entry.
- [ ] All other sound effects still work.