### PR TITLE
Throttle hit SFX to ~10/sec to kill metallic buzz on sustained fire, Closes #121

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=32"></script>
-<script src="js/config.js?v=32"></script>
-<script src="js/i18n.js?v=32"></script>
-<script src="js/globals.js?v=32"></script>
-<script src="js/audio.js?v=32"></script>
-<script src="js/core.js?v=32"></script>
-<script src="js/helpers.js?v=32"></script>
-<script src="js/spawn.js?v=32"></script>
-<script src="js/combat.js?v=32"></script>
-<script src="js/draw.js?v=32"></script>
-<script src="js/hud.js?v=32"></script>
-<script src="js/update_timers.js?v=32"></script>
-<script src="js/update_collision.js?v=32"></script>
-<script src="js/update_enemies.js?v=32"></script>
-<script src="js/update_world.js?v=32"></script>
-<script src="js/update_effects.js?v=32"></script>
-<script src="js/update.js?v=32"></script>
-<script src="js/render.js?v=32"></script>
-<script src="js/achievements.js?v=32"></script>
-<script src="js/shop.js?v=32"></script>
-<script src="js/leaderboard.js?v=32"></script>
-<script src="js/input.js?v=32"></script>
-<script src="js/ui.js?v=32"></script>
-<script src="js/tutorial.js?v=32"></script>
-<script src="js/main.js?v=32"></script>
+<script src="js/crypto.js?v=33"></script>
+<script src="js/config.js?v=33"></script>
+<script src="js/i18n.js?v=33"></script>
+<script src="js/globals.js?v=33"></script>
+<script src="js/audio.js?v=33"></script>
+<script src="js/core.js?v=33"></script>
+<script src="js/helpers.js?v=33"></script>
+<script src="js/spawn.js?v=33"></script>
+<script src="js/combat.js?v=33"></script>
+<script src="js/draw.js?v=33"></script>
+<script src="js/hud.js?v=33"></script>
+<script src="js/update_timers.js?v=33"></script>
+<script src="js/update_collision.js?v=33"></script>
+<script src="js/update_enemies.js?v=33"></script>
+<script src="js/update_world.js?v=33"></script>
+<script src="js/update_effects.js?v=33"></script>
+<script src="js/update.js?v=33"></script>
+<script src="js/render.js?v=33"></script>
+<script src="js/achievements.js?v=33"></script>
+<script src="js/shop.js?v=33"></script>
+<script src="js/leaderboard.js?v=33"></script>
+<script src="js/input.js?v=33"></script>
+<script src="js/ui.js?v=33"></script>
+<script src="js/tutorial.js?v=33"></script>
+<script src="js/main.js?v=33"></script>
 </body>
 </html>

--- a/docs/js/update_collision.js
+++ b/docs/js/update_collision.js
@@ -1,6 +1,13 @@
 // ============================================================
 // UPDATE SUBSYSTEM: Bullet physics and collision detection
 // ============================================================
+// Time-window throttle for the 'hit' SFX. Once-per-frame deduplication is
+// not enough — at 60fps with sustained contacts the synth tails overlap
+// into a metallic drone. Cap the play rate to ~10/sec so each landing
+// group still gets an audible punch but the buzz goes away.
+let _lastHitSoundT = 0;
+const HIT_SFX_MIN_INTERVAL_MS = 100;
+
 function updateBulletCollisions(g, dtF) {
     // Bullets
     g.bullets.forEach(b => {
@@ -37,8 +44,7 @@ function updateBulletCollisions(g, dtF) {
     if (g.bullets.length > bulletLimit) g.bullets.splice(0, g.bullets.length - Math.floor(bulletLimit * 0.7));
 
     // Bullet-enemy collision
-    // Per-frame throttle maps to avoid redundant work when many bullets hit same frame
-    let hitSoundedThisFrame = false;         // play hit sound at most once per frame
+    // Per-frame throttle map to avoid redundant work when many bullets hit same frame
     const enemyDmgMap = new Map();           // enemy -> merged damage payload for this frame
     g.bullets.forEach(b => {
         if (b.dead) return; // lingering impact flash, no more collisions
@@ -102,9 +108,10 @@ function updateBulletCollisions(g, dtF) {
                 }
                 e.hp -= hitDmg;
                 e.hitFlash = 4;
-                if (!hitSoundedThisFrame) {
+                const _hitNow = performance.now();
+                if (_hitNow - _lastHitSoundT >= HIT_SFX_MIN_INTERVAL_MS) {
                     playSound('hit');
-                    hitSoundedThisFrame = true;
+                    _lastHitSoundT = _hitNow;
                 }
                 addImpactFeedback(e.x, e.z, isCrit
                     ? {


### PR DESCRIPTION
## Summary
The hit sound was guarded only by a per-frame flag in `update_collision.js`. At 60 fps with sustained contacts (which is most of the second half of any wave) the 80 ms square-wave synth tails overlapped into a continuous low-frequency drone — exactly the "重金属嗡" the user described. The mp3 path has the same issue: dozens of overlapping copies of the same short clip stack into a buzz.

This PR replaces the per-frame guard with a `performance.now()` time-window throttle: `HIT_SFX_MIN_INTERVAL_MS = 100`. Each landing group still triggers an audible punch (max ~10 plays/sec), but sustained fire no longer collapses into a drone.

Cache-buster bumped `v=32` → `v=33` so returning visitors get the new behavior without a hard refresh.

## Test plan
- [ ] Hard-refresh, start L1: BGM plays as normal (regression check after #120 restore).
- [ ] First wave reaches you: hit sound fires on contact, no continuous buzz/hum.
- [ ] Late game with many enemies: still no metallic drone, hit feedback still audible per group.
- [ ] Crit hits still produce the heavier impact-feedback effect (visual + screen shake unchanged).

Closes #121