### PR TITLE
Centralise SFX throttle, kill explosion-induced heavy-metal hum, Closes #123

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=33"></script>
-<script src="js/config.js?v=33"></script>
-<script src="js/i18n.js?v=33"></script>
-<script src="js/globals.js?v=33"></script>
-<script src="js/audio.js?v=33"></script>
-<script src="js/core.js?v=33"></script>
-<script src="js/helpers.js?v=33"></script>
-<script src="js/spawn.js?v=33"></script>
-<script src="js/combat.js?v=33"></script>
-<script src="js/draw.js?v=33"></script>
-<script src="js/hud.js?v=33"></script>
-<script src="js/update_timers.js?v=33"></script>
-<script src="js/update_collision.js?v=33"></script>
-<script src="js/update_enemies.js?v=33"></script>
-<script src="js/update_world.js?v=33"></script>
-<script src="js/update_effects.js?v=33"></script>
-<script src="js/update.js?v=33"></script>
-<script src="js/render.js?v=33"></script>
-<script src="js/achievements.js?v=33"></script>
-<script src="js/shop.js?v=33"></script>
-<script src="js/leaderboard.js?v=33"></script>
-<script src="js/input.js?v=33"></script>
-<script src="js/ui.js?v=33"></script>
-<script src="js/tutorial.js?v=33"></script>
-<script src="js/main.js?v=33"></script>
+<script src="js/crypto.js?v=34"></script>
+<script src="js/config.js?v=34"></script>
+<script src="js/i18n.js?v=34"></script>
+<script src="js/globals.js?v=34"></script>
+<script src="js/audio.js?v=34"></script>
+<script src="js/core.js?v=34"></script>
+<script src="js/helpers.js?v=34"></script>
+<script src="js/spawn.js?v=34"></script>
+<script src="js/combat.js?v=34"></script>
+<script src="js/draw.js?v=34"></script>
+<script src="js/hud.js?v=34"></script>
+<script src="js/update_timers.js?v=34"></script>
+<script src="js/update_collision.js?v=34"></script>
+<script src="js/update_enemies.js?v=34"></script>
+<script src="js/update_world.js?v=34"></script>
+<script src="js/update_effects.js?v=34"></script>
+<script src="js/update.js?v=34"></script>
+<script src="js/render.js?v=34"></script>
+<script src="js/achievements.js?v=34"></script>
+<script src="js/shop.js?v=34"></script>
+<script src="js/leaderboard.js?v=34"></script>
+<script src="js/input.js?v=34"></script>
+<script src="js/ui.js?v=34"></script>
+<script src="js/tutorial.js?v=34"></script>
+<script src="js/main.js?v=34"></script>
 </body>
 </html>

--- a/docs/js/audio.js
+++ b/docs/js/audio.js
@@ -26,11 +26,11 @@ const SOUND_DEFS = {
     shoot_shotgun:  { file: 'assets/audio/shoot_shotgun.mp3',  vol: 0.35 },
     shoot_laser:    { file: 'assets/audio/shoot_laser.mp3',    vol: 0.3  },
     shoot_rocket:   { file: 'assets/audio/shoot_rocket.mp3',   vol: 0.3  },
-    explosion:      { file: 'assets/audio/explosion.mp3',      vol: 0.4  },
+    explosion:      { file: 'assets/audio/explosion.mp3',      vol: 0.22 },
     gate_good:      { file: 'assets/audio/gate_good.mp3',      vol: 0.5  },
     gate_bad:       { file: 'assets/audio/gate_bad.mp3',       vol: 0.5  },
     weapon_pickup:  { file: 'assets/audio/weapon_pickup.mp3',  vol: 0.5  },
-    hit:            { file: 'assets/audio/hit.mp3',            vol: 0.25 },
+    hit:            { file: 'assets/audio/hit.mp3',            vol: 0.16 },
     wave_start:     { file: 'assets/audio/wave_start.mp3',     vol: 0.5  },
 };
 
@@ -132,8 +132,22 @@ function setBGMVolume(vol) {
     if (_bgmGain) _bgmGain.gain.value = vol;
 }
 
+// Per-type throttle for SFX whose tails would otherwise stack into a drone
+// during sustained fire. The synth fallback for `explosion` is a 250ms
+// 150→30Hz sawtooth — repeated kills overlap into a continuous heavy-metal
+// hum. `hit` has the same problem at smaller scale. Cap their play rate
+// here so every call site is covered by a single throttle.
+const _SFX_MIN_INTERVAL_MS = { hit: 90, explosion: 200 };
+const _lastSfxT = {};
+
 function playSound(type) {
     if (!audioCtx) return;
+    const minGap = _SFX_MIN_INTERVAL_MS[type];
+    if (minGap !== undefined) {
+        const now = performance.now();
+        if (now - (_lastSfxT[type] || 0) < minGap) return;
+        _lastSfxT[type] = now;
+    }
     // Ensure context is running (user gesture may have happened since init)
     if (audioCtx.state === 'suspended') audioCtx.resume();
 

--- a/docs/js/update_collision.js
+++ b/docs/js/update_collision.js
@@ -1,12 +1,9 @@
 // ============================================================
 // UPDATE SUBSYSTEM: Bullet physics and collision detection
 // ============================================================
-// Time-window throttle for the 'hit' SFX. Once-per-frame deduplication is
-// not enough — at 60fps with sustained contacts the synth tails overlap
-// into a metallic drone. Cap the play rate to ~10/sec so each landing
-// group still gets an audible punch but the buzz goes away.
-let _lastHitSoundT = 0;
-const HIT_SFX_MIN_INTERVAL_MS = 100;
+// Note: hit / explosion SFX rate-limiting is now centralised in
+// audio.js playSound (_SFX_MIN_INTERVAL_MS). Call sites here just call
+// playSound(...) and the throttle takes care of the rest.
 
 function updateBulletCollisions(g, dtF) {
     // Bullets
@@ -108,11 +105,7 @@ function updateBulletCollisions(g, dtF) {
                 }
                 e.hp -= hitDmg;
                 e.hitFlash = 4;
-                const _hitNow = performance.now();
-                if (_hitNow - _lastHitSoundT >= HIT_SFX_MIN_INTERVAL_MS) {
-                    playSound('hit');
-                    _lastHitSoundT = _hitNow;
-                }
+                playSound('hit');
                 addImpactFeedback(e.x, e.z, isCrit
                     ? {
                         color: 0xffc24b,


### PR DESCRIPTION
## Summary
After #122 the user still hears the heavy-metal buzz. The dominant overlap source turned out to be **explosion**, not hit. Five call sites trigger `playSound('explosion')` (every kill in `helpers.js:87`, rocket AOE, troop loss, etc.), and the synth fallback is a 250 ms 150 → 30 Hz sawtooth at gain 0.15. Sawtooth + low frequency + 250 ms duration + sustained kills = continuous heavy-metal drone. Even the mp3 path stacks the same way.

This PR:
1. **Moves the SFX throttle to `audio.js playSound`** so every call site is covered:
   ```js
   const _SFX_MIN_INTERVAL_MS = { hit: 90, explosion: 200 };
   ```
2. **Drops volumes a notch** since they were tuned before the throttle:
   - `hit` 0.25 → 0.16
   - `explosion` 0.40 → 0.22
3. **Reverts the now-redundant call-site throttle** in `update_collision.js` introduced by #122.
4. **Bumps cache-buster** `?v=33` → `?v=34`.

Other sounds (shoot, gate_*, weapon_pickup) are NOT in the throttle table, so they keep their full per-call playback.

## Test plan
- [ ] Hard-refresh, start L1: BGM + shoot + first hit → no continuous buzz.
- [ ] First wave clears with multiple kills in succession → no heavy-metal drone, individual explosions still audible.
- [ ] Boss fight with rocket weapon (multiple AOE detonations): explosions still distinct, not stacked.
- [ ] Tutorial intact: hit / explosion still fire on the demo boss kill.

Closes #123