### PR TITLE
Mute hit and explosion SFX entirely, Closes #125

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=34"></script>
-<script src="js/config.js?v=34"></script>
-<script src="js/i18n.js?v=34"></script>
-<script src="js/globals.js?v=34"></script>
-<script src="js/audio.js?v=34"></script>
-<script src="js/core.js?v=34"></script>
-<script src="js/helpers.js?v=34"></script>
-<script src="js/spawn.js?v=34"></script>
-<script src="js/combat.js?v=34"></script>
-<script src="js/draw.js?v=34"></script>
-<script src="js/hud.js?v=34"></script>
-<script src="js/update_timers.js?v=34"></script>
-<script src="js/update_collision.js?v=34"></script>
-<script src="js/update_enemies.js?v=34"></script>
-<script src="js/update_world.js?v=34"></script>
-<script src="js/update_effects.js?v=34"></script>
-<script src="js/update.js?v=34"></script>
-<script src="js/render.js?v=34"></script>
-<script src="js/achievements.js?v=34"></script>
-<script src="js/shop.js?v=34"></script>
-<script src="js/leaderboard.js?v=34"></script>
-<script src="js/input.js?v=34"></script>
-<script src="js/ui.js?v=34"></script>
-<script src="js/tutorial.js?v=34"></script>
-<script src="js/main.js?v=34"></script>
+<script src="js/crypto.js?v=35"></script>
+<script src="js/config.js?v=35"></script>
+<script src="js/i18n.js?v=35"></script>
+<script src="js/globals.js?v=35"></script>
+<script src="js/audio.js?v=35"></script>
+<script src="js/core.js?v=35"></script>
+<script src="js/helpers.js?v=35"></script>
+<script src="js/spawn.js?v=35"></script>
+<script src="js/combat.js?v=35"></script>
+<script src="js/draw.js?v=35"></script>
+<script src="js/hud.js?v=35"></script>
+<script src="js/update_timers.js?v=35"></script>
+<script src="js/update_collision.js?v=35"></script>
+<script src="js/update_enemies.js?v=35"></script>
+<script src="js/update_world.js?v=35"></script>
+<script src="js/update_effects.js?v=35"></script>
+<script src="js/update.js?v=35"></script>
+<script src="js/render.js?v=35"></script>
+<script src="js/achievements.js?v=35"></script>
+<script src="js/shop.js?v=35"></script>
+<script src="js/leaderboard.js?v=35"></script>
+<script src="js/input.js?v=35"></script>
+<script src="js/ui.js?v=35"></script>
+<script src="js/tutorial.js?v=35"></script>
+<script src="js/main.js?v=35"></script>
 </body>
 </html>

--- a/docs/js/audio.js
+++ b/docs/js/audio.js
@@ -132,16 +132,23 @@ function setBGMVolume(vol) {
     if (_bgmGain) _bgmGain.gain.value = vol;
 }
 
+// SFX silenced because their synth fallbacks (sawtooth / square) and
+// stacked tails were heard as a sustained heavy-metal drone during
+// combat. Throttling and volume drops still left the buzz audible —
+// visual feedback (hit flash, screen shake, particles, damage numbers)
+// already covers every contact and kill, so the audio is dropped
+// entirely. Re-enable later by removing entries from this set.
+const _MUTED_SFX = new Set(['hit', 'explosion']);
+
 // Per-type throttle for SFX whose tails would otherwise stack into a drone
-// during sustained fire. The synth fallback for `explosion` is a 250ms
-// 150→30Hz sawtooth — repeated kills overlap into a continuous heavy-metal
-// hum. `hit` has the same problem at smaller scale. Cap their play rate
-// here so every call site is covered by a single throttle.
+// during sustained fire. Currently unused while hit/explosion are muted,
+// but the table is kept for future SFX that need rate limiting.
 const _SFX_MIN_INTERVAL_MS = { hit: 90, explosion: 200 };
 const _lastSfxT = {};
 
 function playSound(type) {
     if (!audioCtx) return;
+    if (_MUTED_SFX.has(type)) return;
     const minGap = _SFX_MIN_INTERVAL_MS[type];
     if (minGap !== undefined) {
         const now = performance.now();


### PR DESCRIPTION
## Summary
After #122 (hit throttle) and #124 (explosion throttle + volume drop), the user still hears the buzz — quieter, but present. The synth fallbacks for both SFX (square 200→80 Hz for hit, sawtooth 150→30 Hz for explosion) carry the harmonic profile that produces the metallic drone all on their own; partial measures don't get rid of it. Even one play has the buzzy quality.

This PR mutes both SFX outright via a `_MUTED_SFX` short-circuit at the top of `playSound`. Visual feedback (hit flash on enemies, screen flash, screen shake, particle bursts, damage numbers, score popups) already covers every contact and kill, so dropping the audio costs no information.

BGM, shoot, shoot_shotgun, shoot_laser, shoot_rocket, gate_good, gate_bad, weapon_pickup, wave_start — all unchanged. Re-enabling either SFX is a one-line drop from `_MUTED_SFX`. Throttle table and reduced volumes kept so re-enable is plug-and-play.

Cache-buster bumped `?v=34` → `?v=35`.

## Test plan
- [ ] Hard-refresh, start L1: shoot pew + BGM as normal, **no** buzz on contact, **no** buzz on kill.
- [ ] Walk through a +/- gate: `gate_good` / `gate_bad` still fire.
- [ ] Walk through a weapon gate: `weapon_pickup` still fires.
- [ ] Press [1] / [2] for shield / frenzy: `weapon_pickup` still cues activation.
- [ ] Tutorial intact: kills no longer audio-cue but still visually cue (death body, score popup, particles).

Closes #125