### PR TITLE
Make weapon panel self-managing — drop collapse toggle, auto-hide skill tiles, Closes #127

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
 <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="stylesheet" href="style.css?v=17">
+<link rel="stylesheet" href="style.css?v=18">
 <style>
 /* p5.js canvas sits behind all overlays.
    Use "body > canvas" to target only the p5 canvas (direct child of body),
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=35"></script>
-<script src="js/config.js?v=35"></script>
-<script src="js/i18n.js?v=35"></script>
-<script src="js/globals.js?v=35"></script>
-<script src="js/audio.js?v=35"></script>
-<script src="js/core.js?v=35"></script>
-<script src="js/helpers.js?v=35"></script>
-<script src="js/spawn.js?v=35"></script>
-<script src="js/combat.js?v=35"></script>
-<script src="js/draw.js?v=35"></script>
-<script src="js/hud.js?v=35"></script>
-<script src="js/update_timers.js?v=35"></script>
-<script src="js/update_collision.js?v=35"></script>
-<script src="js/update_enemies.js?v=35"></script>
-<script src="js/update_world.js?v=35"></script>
-<script src="js/update_effects.js?v=35"></script>
-<script src="js/update.js?v=35"></script>
-<script src="js/render.js?v=35"></script>
-<script src="js/achievements.js?v=35"></script>
-<script src="js/shop.js?v=35"></script>
-<script src="js/leaderboard.js?v=35"></script>
-<script src="js/input.js?v=35"></script>
-<script src="js/ui.js?v=35"></script>
-<script src="js/tutorial.js?v=35"></script>
-<script src="js/main.js?v=35"></script>
+<script src="js/crypto.js?v=36"></script>
+<script src="js/config.js?v=36"></script>
+<script src="js/i18n.js?v=36"></script>
+<script src="js/globals.js?v=36"></script>
+<script src="js/audio.js?v=36"></script>
+<script src="js/core.js?v=36"></script>
+<script src="js/helpers.js?v=36"></script>
+<script src="js/spawn.js?v=36"></script>
+<script src="js/combat.js?v=36"></script>
+<script src="js/draw.js?v=36"></script>
+<script src="js/hud.js?v=36"></script>
+<script src="js/update_timers.js?v=36"></script>
+<script src="js/update_collision.js?v=36"></script>
+<script src="js/update_enemies.js?v=36"></script>
+<script src="js/update_world.js?v=36"></script>
+<script src="js/update_effects.js?v=36"></script>
+<script src="js/update.js?v=36"></script>
+<script src="js/render.js?v=36"></script>
+<script src="js/achievements.js?v=36"></script>
+<script src="js/shop.js?v=36"></script>
+<script src="js/leaderboard.js?v=36"></script>
+<script src="js/input.js?v=36"></script>
+<script src="js/ui.js?v=36"></script>
+<script src="js/tutorial.js?v=36"></script>
+<script src="js/main.js?v=36"></script>
 </body>
 </html>

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -318,58 +318,15 @@ function activateSkillWeapon() {
 // ============================================================
 // WEAPON SLOTS
 // ============================================================
-const WEAPON_PANEL_COLLAPSE_KEY = 'bridgeAssault_weaponPanelCollapsed';
-
-function _loadWeaponPanelCollapsed() {
-    try {
-        return localStorage.getItem(WEAPON_PANEL_COLLAPSE_KEY) === '1';
-    } catch {
-        return false;
-    }
-}
-
-function _saveWeaponPanelCollapsed(collapsed) {
-    try {
-        localStorage.setItem(WEAPON_PANEL_COLLAPSE_KEY, collapsed ? '1' : '0');
-    } catch {}
-}
-
-function setWeaponPanelCollapsed(collapsed) {
-    const slotsDiv = document.getElementById('weaponSlots');
-    if (!slotsDiv) return;
-    slotsDiv.classList.toggle('collapsed', !!collapsed);
-    const toggleBtn = document.getElementById('weaponPanelToggle');
-    if (toggleBtn) {
-        toggleBtn.textContent = collapsed ? '▶' : '◀';
-        toggleBtn.classList.toggle('is-collapsed', !!collapsed);
-        toggleBtn.title = collapsed ? T('hud.panel.show') : T('hud.panel.hide');
-        toggleBtn.setAttribute('aria-label', toggleBtn.title);
-    }
-    _saveWeaponPanelCollapsed(!!collapsed);
-}
-
-function toggleWeaponPanel() {
-    const slotsDiv = document.getElementById('weaponSlots');
-    if (!slotsDiv) return;
-    setWeaponPanelCollapsed(!slotsDiv.classList.contains('collapsed'));
-}
+// Panel auto-manages itself: the current-weapon badge is always shown,
+// each skill tile (shield / frenzy) is shown only when it has something
+// to surface (≥1 charge, currently active, or on cooldown). No manual
+// collapse toggle and no persisted state.
 
 function initWeaponSlots() {
     const slotsDiv = document.getElementById('weaponSlots');
     if (!slotsDiv) return;
     slotsDiv.innerHTML = '';
-
-    const toggleBtn = document.createElement('button');
-    toggleBtn.id = 'weaponPanelToggle';
-    toggleBtn.className = 'weapon-panel-toggle';
-    toggleBtn.type = 'button';
-    toggleBtn.textContent = '◀';
-    toggleBtn.addEventListener('click', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        toggleWeaponPanel();
-    });
-    slotsDiv.appendChild(toggleBtn);
 
     const currentBadge = document.createElement('div');
     currentBadge.id = 'currentWeaponBadge';
@@ -402,10 +359,12 @@ function initWeaponSlots() {
             <div class="wslot-cd"></div>
         `;
         slot.addEventListener('click', () => activateWeaponByKey(key));
+        // Hidden by default; updateWeaponSlots reveals each tile when it
+        // becomes relevant (charges, active, or cooldown).
+        slot.style.display = 'none';
         slotsDiv.appendChild(slot);
     }
     slotsDiv.style.display = 'flex';
-    setWeaponPanelCollapsed(_loadWeaponPanelCollapsed());
 }
 
 function _getCurrentWeaponDisplay() {
@@ -452,16 +411,6 @@ function updateCurrentWeaponBadge() {
     const badge = document.getElementById('currentWeaponBadge');
     if (!badge) return;
 
-    const toggleBtn = document.getElementById('weaponPanelToggle');
-    const slotsDiv = document.getElementById('weaponSlots');
-    if (toggleBtn && slotsDiv) {
-        const collapsed = slotsDiv.classList.contains('collapsed');
-        toggleBtn.textContent = collapsed ? '▶' : '◀';
-        toggleBtn.classList.toggle('is-collapsed', collapsed);
-        toggleBtn.title = collapsed ? T('hud.panel.show') : T('hud.panel.hide');
-        toggleBtn.setAttribute('aria-label', toggleBtn.title);
-    }
-
     const labelEl = badge.querySelector('.current-weapon-label');
     if (labelEl) labelEl.textContent = T('hud.current.weapon');
 
@@ -488,38 +437,43 @@ function updateWeaponSlots() {
         const key = slot.dataset.weapon;
         const w = SHOP_WEAPONS[key];
         if (!w) return;
-        {
-            const count = charges[key] || 0;
-            const isActive = key === 'invincibility' ? g.shieldActive : g.stimulantActive;
-            const isOnCooldown = key === 'invincibility' ? (g.skillCooldown > 0) : (g.stimulantCooldown > 0);
-            const activeTimer = key === 'invincibility' ? g.shieldTimer : g.stimulantTimer;
-            const activeDuration = (key === 'invincibility' ? WEAPON_DEFS['invincibility'].duration : SHOP_WEAPONS['stimulant'].duration) * 1000;
-            const cdSec = Math.ceil((key === 'invincibility' ? g.skillCooldown : g.stimulantCooldown) / 1000);
-            const countEl = slot.querySelector('.wslot-count');
-            if (countEl) {
-                countEl.textContent = `\u00D7${count}`;
-                countEl.style.color = isActive ? '#ffd700' : (!isOnCooldown && count > 0) ? w.color : 'rgba(255,255,255,0.5)';
-            }
-            const cdEl = slot.querySelector('.wslot-cd');
-            if (cdEl) {
-                if (isActive) { cdEl.textContent = Math.ceil(activeTimer / 1000) + 's'; cdEl.style.color = '#ffd700'; cdEl.style.display = 'flex'; }
-                else if (isOnCooldown) { cdEl.textContent = cdSec + 's'; cdEl.style.color = '#999'; cdEl.style.display = 'flex'; }
-                else { cdEl.style.display = 'none'; }
-            }
-            const barFill = slot.querySelector('.wslot-bar-fill');
-            if (barFill) {
-                if (isActive) {
-                    barFill.style.width = Math.max(0, activeTimer / activeDuration) * 100 + '%';
-                    barFill.style.background = w.color;
-                    slot.querySelector('.wslot-bar').style.display = 'block';
-                } else { slot.querySelector('.wslot-bar').style.display = 'none'; }
-            }
-            slot.className = 'wslot';
-            if (isActive) { slot.classList.add('wslot-active'); slot.style.borderColor = '#ffd700'; }
-            else if (count <= 0) { slot.classList.add('wslot-empty'); slot.style.borderColor = 'rgba(255,255,255,0.08)'; }
-            else if (isOnCooldown) { slot.classList.add('wslot-dim'); slot.style.borderColor = 'rgba(255,255,255,0.12)'; }
-            else { slot.classList.add('wslot-ready'); slot.style.borderColor = w.color; }
+        const count = charges[key] || 0;
+        const isActive = key === 'invincibility' ? g.shieldActive : g.stimulantActive;
+        const isOnCooldown = key === 'invincibility' ? (g.skillCooldown > 0) : (g.stimulantCooldown > 0);
+        // Auto-hide when the slot has nothing to surface — fresh runs start
+        // with both tiles invisible; they materialise the moment the player
+        // owns a charge, triggers it, or it enters cooldown.
+        if (count <= 0 && !isActive && !isOnCooldown) {
+            slot.style.display = 'none';
+            return;
         }
+        slot.style.display = 'flex';
+        const activeTimer = key === 'invincibility' ? g.shieldTimer : g.stimulantTimer;
+        const activeDuration = (key === 'invincibility' ? WEAPON_DEFS['invincibility'].duration : SHOP_WEAPONS['stimulant'].duration) * 1000;
+        const cdSec = Math.ceil((key === 'invincibility' ? g.skillCooldown : g.stimulantCooldown) / 1000);
+        const countEl = slot.querySelector('.wslot-count');
+        if (countEl) {
+            countEl.textContent = `\u00D7${count}`;
+            countEl.style.color = isActive ? '#ffd700' : (!isOnCooldown && count > 0) ? w.color : 'rgba(255,255,255,0.5)';
+        }
+        const cdEl = slot.querySelector('.wslot-cd');
+        if (cdEl) {
+            if (isActive) { cdEl.textContent = Math.ceil(activeTimer / 1000) + 's'; cdEl.style.color = '#ffd700'; cdEl.style.display = 'flex'; }
+            else if (isOnCooldown) { cdEl.textContent = cdSec + 's'; cdEl.style.color = '#999'; cdEl.style.display = 'flex'; }
+            else { cdEl.style.display = 'none'; }
+        }
+        const barFill = slot.querySelector('.wslot-bar-fill');
+        if (barFill) {
+            if (isActive) {
+                barFill.style.width = Math.max(0, activeTimer / activeDuration) * 100 + '%';
+                barFill.style.background = w.color;
+                slot.querySelector('.wslot-bar').style.display = 'block';
+            } else { slot.querySelector('.wslot-bar').style.display = 'none'; }
+        }
+        slot.className = 'wslot';
+        if (isActive) { slot.classList.add('wslot-active'); slot.style.borderColor = '#ffd700'; }
+        else if (isOnCooldown) { slot.classList.add('wslot-dim'); slot.style.borderColor = 'rgba(255,255,255,0.12)'; }
+        else { slot.classList.add('wslot-ready'); slot.style.borderColor = w.color; }
     });
 }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -875,59 +875,6 @@ body::after {
     transition: background 0.15s, box-shadow 0.15s, border-color 0.15s, padding 0.15s;
 }
 
-.weapon-panel-toggle {
-    position: absolute;
-    top: -10px;
-    right: 6px;
-    width: 28px;
-    height: 22px;
-    padding: 0;
-    border-radius: 999px;
-    border: 1px solid rgba(120, 190, 255, 0.55);
-    background: linear-gradient(180deg, rgba(34, 80, 130, 0.95), rgba(20, 40, 80, 0.95));
-    color: #c8e8ff;
-    font-size: 13px;
-    font-family: 'Courier New', monospace;
-    font-weight: bold;
-    letter-spacing: 0;
-    line-height: 1;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    -webkit-tap-highlight-color: transparent;
-}
-
-.weapon-panel-toggle:hover {
-    background: linear-gradient(180deg, rgba(46, 106, 166, 0.95), rgba(24, 62, 110, 0.95));
-}
-
-.weapon-panel-toggle:active {
-    transform: scale(0.94);
-}
-
-.weapon-panel-toggle.is-collapsed {
-    border-color: rgba(130, 220, 180, 0.62);
-    background: linear-gradient(180deg, rgba(26, 118, 88, 0.95), rgba(18, 78, 62, 0.95));
-    color: #d7ffe8;
-}
-
-#weaponSlots.collapsed {
-    width: auto;
-    padding: 5px 6px;
-    background: rgba(8,8,20,0.5);
-    border-color: rgba(255,255,255,0.12);
-}
-
-#weaponSlots.collapsed > :not(.weapon-panel-toggle) {
-    display: none !important;
-}
-
-#weaponSlots.collapsed .weapon-panel-toggle {
-    top: 4px;
-    right: 6px;
-}
-
 .current-weapon-badge {
     min-width: 100%;
     max-width: 100%;
@@ -1331,13 +1278,6 @@ body::after {
     }
     .current-weapon-meta {
         font-size: min(9px, 2.5vw);
-    }
-    .weapon-panel-toggle {
-        top: -8px;
-        right: 6px;
-        width: 26px;
-        height: 20px;
-        font-size: 12px;
     }
     .wslot {
         width: min(62px, 20vw);


### PR DESCRIPTION
## Summary
The HUD weapon panel still required a mouse click on the ◀/▶ toggle to collapse or expand. User reports that's unfriendly. Make the panel manage itself:

- **Drop the toggle entirely.** Remove the toggle button creation in `initWeaponSlots`, the toggle bookkeeping inside `updateCurrentWeaponBadge`, the helpers `setWeaponPanelCollapsed` / `toggleWeaponPanel` / `_load`/`_saveWeaponPanelCollapsed`, and the `bridgeAssault_weaponPanelCollapsed` localStorage key.
- **Auto-hide skill tiles** (shield / frenzy) when irrelevant — only render when the player owns ≥1 charge, the skill is active, or it is on cooldown. Fresh runs show just the current-weapon badge; a tile materialises the moment the player buys / triggers it; disappears once there's nothing to show again.
- **Strip dead CSS** for `.weapon-panel-toggle` and `#weaponSlots.collapsed` (desktop + mobile rules).

Cache-buster bumped `?v=35` → `?v=36` and `style.css?v=17` → `?v=18`.

## Test plan
- [ ] Hard-refresh, start L1: panel shows only the current-weapon badge (no tiles, no toggle).
- [ ] Buy a Shield charge in the shop, return to a level: a single skill tile appears with hotkey `[1]` and `×N` count.
- [ ] Press `1`: tile shows active timer + duration bar; when expired, switches to cooldown countdown.
- [ ] Cooldown ends with 0 charges remaining: tile disappears again.
- [ ] Same path with stimulant on `[2]`.
- [ ] Walk through a SHOTGUN / LASER / ROCKET gate: current-weapon badge updates icon + name. No toggle needed, no manual action.

Closes #127