### PR TITLE
Bump enemy difficulty: HP 3->4, dmg every 4 waves, heavy chance 0.12->0.15, Closes #129

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=36"></script>
-<script src="js/config.js?v=36"></script>
-<script src="js/i18n.js?v=36"></script>
-<script src="js/globals.js?v=36"></script>
-<script src="js/audio.js?v=36"></script>
-<script src="js/core.js?v=36"></script>
-<script src="js/helpers.js?v=36"></script>
-<script src="js/spawn.js?v=36"></script>
-<script src="js/combat.js?v=36"></script>
-<script src="js/draw.js?v=36"></script>
-<script src="js/hud.js?v=36"></script>
-<script src="js/update_timers.js?v=36"></script>
-<script src="js/update_collision.js?v=36"></script>
-<script src="js/update_enemies.js?v=36"></script>
-<script src="js/update_world.js?v=36"></script>
-<script src="js/update_effects.js?v=36"></script>
-<script src="js/update.js?v=36"></script>
-<script src="js/render.js?v=36"></script>
-<script src="js/achievements.js?v=36"></script>
-<script src="js/shop.js?v=36"></script>
-<script src="js/leaderboard.js?v=36"></script>
-<script src="js/input.js?v=36"></script>
-<script src="js/ui.js?v=36"></script>
-<script src="js/tutorial.js?v=36"></script>
-<script src="js/main.js?v=36"></script>
+<script src="js/crypto.js?v=37"></script>
+<script src="js/config.js?v=37"></script>
+<script src="js/i18n.js?v=37"></script>
+<script src="js/globals.js?v=37"></script>
+<script src="js/audio.js?v=37"></script>
+<script src="js/core.js?v=37"></script>
+<script src="js/helpers.js?v=37"></script>
+<script src="js/spawn.js?v=37"></script>
+<script src="js/combat.js?v=37"></script>
+<script src="js/draw.js?v=37"></script>
+<script src="js/hud.js?v=37"></script>
+<script src="js/update_timers.js?v=37"></script>
+<script src="js/update_collision.js?v=37"></script>
+<script src="js/update_enemies.js?v=37"></script>
+<script src="js/update_world.js?v=37"></script>
+<script src="js/update_effects.js?v=37"></script>
+<script src="js/update.js?v=37"></script>
+<script src="js/render.js?v=37"></script>
+<script src="js/achievements.js?v=37"></script>
+<script src="js/shop.js?v=37"></script>
+<script src="js/leaderboard.js?v=37"></script>
+<script src="js/input.js?v=37"></script>
+<script src="js/ui.js?v=37"></script>
+<script src="js/tutorial.js?v=37"></script>
+<script src="js/main.js?v=37"></script>
 </body>
 </html>

--- a/docs/js/config.js
+++ b/docs/js/config.js
@@ -30,7 +30,7 @@ const CONFIG = {
     // mid-range while still inside every weapon's effective range.
     BOSS_HOLD_Z: 850,
     GATE_DISTANCE: 300,
-    ENEMY_HP: 3,
+    ENEMY_HP: 4,
     PIXEL_SIZE: 2,
     CLOUD_COUNT: 8,
     VIGNETTE_STRENGTH: 0.4,

--- a/docs/js/spawn.js
+++ b/docs/js/spawn.js
@@ -31,7 +31,7 @@ function spawnEnemyWaveL2() {
     const baseZ = g.cameraZ + CONFIG.SPAWN_DISTANCE;
     const earlyDmgMult = g.wave <= 2 ? 0.5 : 1.0;
     // L2 base damage: significantly higher than L1 (×3)
-    const rawDmg = (1 + Math.floor(g.wave / 5)) * Math.sqrt(af) * earlyDmgMult * 3;
+    const rawDmg = (1 + Math.floor(g.wave / 4)) * Math.sqrt(af) * earlyDmgMult * 3;
     const baseDmg = rawDmg <= 3 ? Math.ceil(rawDmg) : Math.ceil(3 + Math.log2(rawDmg - 2));
 
     for (let r = 0; r < rows; r++) {
@@ -162,7 +162,7 @@ function spawnEnemyWave() {
     // Damage scales with wave × adaptive factor; early waves deal less damage
     // Late-game damage grows more gently: logarithmic growth + soft cap
     const earlyDmgMult = g.wave <= 2 ? 0.5 : 1.0;
-    const rawDmg = (1 + Math.floor(g.wave / 5)) * Math.sqrt(af) * earlyDmgMult;
+    const rawDmg = (1 + Math.floor(g.wave / 4)) * Math.sqrt(af) * earlyDmgMult;
     // Soft cap: growth slows after 3 (log decay), milder late-game damage
     const baseDmg = rawDmg <= 3 ? Math.ceil(rawDmg) : Math.ceil(3 + Math.log2(rawDmg - 2));
     for (let r = 0; r < rows; r++) {
@@ -175,7 +175,7 @@ function spawnEnemyWave() {
             const rawHp = CONFIG.ENEMY_HP + g.wave + Math.floor(g.wave * g.wave / 40);
             const baseHp = Math.ceil(rawHp * af * earlyMult);
             // Heavy enemies: chance also scaled by adaptive factor
-            const heavyChance = g.wave >= 6 ? (0.12 + g.wave * 0.006) * Math.min(1.5, af) : 0;
+            const heavyChance = g.wave >= 6 ? (0.15 + g.wave * 0.006) * Math.min(1.5, af) : 0;
             const isHeavy = Math.random() < heavyChance;
             // Type distribution by tier: common=high weight, elite=low; shifts with wave
             // type0/2: Patrick (common), type1: small dragon (mid), type3: fire dragon (elite)


### PR DESCRIPTION
## Summary
User reports current game is too easy. Three small deltas, all inside the existing formulas:

- `CONFIG.ENEMY_HP` 3 → 4 — affects both L1 and L2 base HP (L2 multiplies by 4 so the bump propagates).
- L1 + L2 damage tier steps up every 4 waves instead of 5.
- L1 heavy-enemy chance base 0.12 → 0.15 — slightly more bulky enemies from wave 6+.

Boss HP / boss damage / shop pricing all untouched. Cache-buster `v=36` → `v=37`.

## Test plan
- [ ] Hard-refresh, play through L1 wave 1-5: enemies feel chunkier but not punishing.
- [ ] Reach wave 8-10: damage step up at wave 8 instead of wave 10 — note when troops drop sharper.
- [ ] L2: base HP and damage feel proportionally higher.

Closes #129