### PR TITLE
Compact top-left weapon panel — smaller footprint, drop redundant label, Closes #131

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
 <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
-<link rel="stylesheet" href="style.css?v=18">
+<link rel="stylesheet" href="style.css?v=19">
 <style>
 /* p5.js canvas sits behind all overlays.
    Use "body > canvas" to target only the p5 canvas (direct child of body),

--- a/docs/style.css
+++ b/docs/style.css
@@ -861,13 +861,13 @@ body::after {
     flex-direction: row;
     flex-wrap: wrap;
     align-content: flex-start;
-    gap: 6px;
-    width: min(300px, 24vw);
+    gap: 5px;
+    width: min(220px, 18vw);
     z-index: 5;
     pointer-events: auto;
-    padding: 7px;
+    padding: 5px;
     background: rgba(8,8,20,0.72);
-    border-radius: 14px;
+    border-radius: 12px;
     border: 1px solid rgba(255,255,255,0.07);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
@@ -878,21 +878,18 @@ body::after {
 .current-weapon-badge {
     min-width: 100%;
     max-width: 100%;
-    border-radius: 10px;
+    border-radius: 8px;
     border: 1px solid rgba(255,255,255,0.16);
     background: rgba(255,255,255,0.04);
-    padding: 5px 8px;
+    padding: 4px 6px;
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 3px;
 }
 
+/* Label row hidden — the icon + name already convey "current weapon" */
 .current-weapon-label {
-    font-family: 'Courier New', monospace;
-    font-size: min(10px, 2vw);
-    letter-spacing: 1px;
-    color: rgba(255,255,255,0.58);
-    text-transform: uppercase;
+    display: none;
 }
 
 .current-weapon-main {
@@ -900,17 +897,17 @@ body::after {
     display: grid;
     grid-template-columns: auto 1fr;
     align-items: center;
-    column-gap: 8px;
-    min-height: 42px;
+    column-gap: 6px;
+    min-height: 34px;
     border: 1px solid color-mix(in srgb, var(--cw-color) 45%, rgba(255,255,255,0.2));
-    border-radius: 8px;
+    border-radius: 7px;
     background: color-mix(in srgb, var(--cw-color) 14%, rgba(10,10,24,0.85));
-    padding: 4px 6px;
+    padding: 3px 5px;
 }
 
 .current-weapon-icon {
-    width: 34px;
-    height: 34px;
+    width: 26px;
+    height: 26px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -918,32 +915,32 @@ body::after {
 }
 
 .current-weapon-icon svg {
-    width: 30px;
-    height: 30px;
+    width: 22px;
+    height: 22px;
 }
 
 .current-weapon-name {
     font-family: 'Courier New', monospace;
     font-weight: bold;
-    letter-spacing: 0.6px;
+    letter-spacing: 0.5px;
     color: #fff;
-    font-size: min(13px, 2.5vw);
+    font-size: min(12px, 2.4vw);
     line-height: 1.05;
 }
 
 .current-weapon-meta {
     font-family: 'Courier New', monospace;
-    font-size: min(10px, 2vw);
+    font-size: min(9px, 1.9vw);
     color: rgba(255,255,255,0.72);
-    min-height: 11px;
-    margin-top: 2px;
+    min-height: 9px;
+    margin-top: 1px;
 }
 
 .wslot {
     position: relative;
-    width: min(72px, 15vw);
-    height: min(72px, 15vw);
-    border-radius: 9px;
+    width: min(56px, 12vw);
+    height: min(56px, 12vw);
+    border-radius: 8px;
     border: 1.5px solid rgba(255,255,255,0.12);
     background: rgba(255,255,255,0.04);
     display: flex;
@@ -951,7 +948,7 @@ body::after {
     align-items: center;
     justify-content: center;
     gap: 2px;
-    padding: 6px 4px 4px;
+    padding: 4px 3px 3px;
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
     transition: border-color 0.2s, background 0.2s, box-shadow 0.2s, opacity 0.2s;
@@ -976,20 +973,20 @@ body::after {
 }
 
 .wslot-icon {
-    font-size: min(26px, 5.5vw);
+    font-size: min(20px, 4.4vw);
     line-height: 1;
     display: flex;
     align-items: center;
     justify-content: center;
 }
 .wslot-icon svg {
-    width: min(24px, 5vw);
-    height: min(24px, 5vw);
+    width: min(18px, 4vw);
+    height: min(18px, 4vw);
 }
 
 .wslot-count {
     font-family: 'Courier New', monospace;
-    font-size: min(12px, 2.5vw);
+    font-size: min(11px, 2.3vw);
     font-weight: bold;
     line-height: 1;
     text-align: center;
@@ -1000,13 +997,13 @@ body::after {
 .wslot-cd {
     position: absolute;
     top: 0; left: 0; right: 0; bottom: 0;
-    border-radius: 7px;
+    border-radius: 6px;
     background: rgba(0,0,0,0.7);
     display: none;
     align-items: center;
     justify-content: center;
     font-family: 'Courier New', monospace;
-    font-size: min(18px, 4vw);
+    font-size: min(14px, 3vw);
     font-weight: bold;
     letter-spacing: 1px;
     text-shadow: 0 1px 4px rgba(0,0,0,0.9);


### PR DESCRIPTION
## Summary
After #128 the panel auto-manages tiles, but the user reports it still feels too big. Pure CSS shrink — no JS, no layout logic changed.

Headline cuts:
- Panel width `min(300px, 24vw)` → `min(220px, 18vw)` (~25 % narrower).
- Hide the "CURRENT WEAPON / 当前武器" label row entirely (the icon + name already convey it).
- Current-weapon icon 34 → 26 px, name font 13 → 12 px.
- Skill tiles 72 → 56 px, icon 24 → 18 px.
- Cooldown timer font 18 → 14 px.

`style.css?v=18` → `?v=19` so returning visitors get the new sizing without a hard refresh.

## Test plan
- [ ] Hard-refresh, start L1: panel is visibly tighter, current-weapon icon + name still legible.
- [ ] Buy a Shield charge → tile appears at the new compact size, hotkey `[1]` still readable.
- [ ] Activate Shield: cooldown timer text still readable inside the tile, duration bar still visible.
- [ ] Walk through a SHOTGUN gate: badge updates icon + name correctly.
- [ ] Mobile breakpoint: the existing media-query overrides still kick in for narrow screens (no regression).

Closes #131