### PR TITLE
Substantially bump Level 2 mob HP and damage multipliers, Closes #133

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=37"></script>
-<script src="js/config.js?v=37"></script>
-<script src="js/i18n.js?v=37"></script>
-<script src="js/globals.js?v=37"></script>
-<script src="js/audio.js?v=37"></script>
-<script src="js/core.js?v=37"></script>
-<script src="js/helpers.js?v=37"></script>
-<script src="js/spawn.js?v=37"></script>
-<script src="js/combat.js?v=37"></script>
-<script src="js/draw.js?v=37"></script>
-<script src="js/hud.js?v=37"></script>
-<script src="js/update_timers.js?v=37"></script>
-<script src="js/update_collision.js?v=37"></script>
-<script src="js/update_enemies.js?v=37"></script>
-<script src="js/update_world.js?v=37"></script>
-<script src="js/update_effects.js?v=37"></script>
-<script src="js/update.js?v=37"></script>
-<script src="js/render.js?v=37"></script>
-<script src="js/achievements.js?v=37"></script>
-<script src="js/shop.js?v=37"></script>
-<script src="js/leaderboard.js?v=37"></script>
-<script src="js/input.js?v=37"></script>
-<script src="js/ui.js?v=37"></script>
-<script src="js/tutorial.js?v=37"></script>
-<script src="js/main.js?v=37"></script>
+<script src="js/crypto.js?v=38"></script>
+<script src="js/config.js?v=38"></script>
+<script src="js/i18n.js?v=38"></script>
+<script src="js/globals.js?v=38"></script>
+<script src="js/audio.js?v=38"></script>
+<script src="js/core.js?v=38"></script>
+<script src="js/helpers.js?v=38"></script>
+<script src="js/spawn.js?v=38"></script>
+<script src="js/combat.js?v=38"></script>
+<script src="js/draw.js?v=38"></script>
+<script src="js/hud.js?v=38"></script>
+<script src="js/update_timers.js?v=38"></script>
+<script src="js/update_collision.js?v=38"></script>
+<script src="js/update_enemies.js?v=38"></script>
+<script src="js/update_world.js?v=38"></script>
+<script src="js/update_effects.js?v=38"></script>
+<script src="js/update.js?v=38"></script>
+<script src="js/render.js?v=38"></script>
+<script src="js/achievements.js?v=38"></script>
+<script src="js/shop.js?v=38"></script>
+<script src="js/leaderboard.js?v=38"></script>
+<script src="js/input.js?v=38"></script>
+<script src="js/ui.js?v=38"></script>
+<script src="js/tutorial.js?v=38"></script>
+<script src="js/main.js?v=38"></script>
 </body>
 </html>

--- a/docs/js/spawn.js
+++ b/docs/js/spawn.js
@@ -30,8 +30,8 @@ function spawnEnemyWaveL2() {
     const rows = Math.ceil(count / 5);
     const baseZ = g.cameraZ + CONFIG.SPAWN_DISTANCE;
     const earlyDmgMult = g.wave <= 2 ? 0.5 : 1.0;
-    // L2 base damage: significantly higher than L1 (×3)
-    const rawDmg = (1 + Math.floor(g.wave / 4)) * Math.sqrt(af) * earlyDmgMult * 3;
+    // L2 base damage: substantially higher than L1 (×5).
+    const rawDmg = (1 + Math.floor(g.wave / 4)) * Math.sqrt(af) * earlyDmgMult * 5;
     const baseDmg = rawDmg <= 3 ? Math.ceil(rawDmg) : Math.ceil(3 + Math.log2(rawDmg - 2));
 
     for (let r = 0; r < rows; r++) {
@@ -40,8 +40,8 @@ function spawnEnemyWaveL2() {
             const spread = CONFIG.ROAD_HALF_WIDTH * 0.7;
             const x = cols === 1 ? 0 : -spread + (spread * 2) * c / (cols - 1);
             const earlyMult = g.wave <= 2 ? 0.5 : 1.0;
-            // L2 base HP: significantly higher than L1 (×4)
-            const rawHp = (CONFIG.ENEMY_HP + g.wave + Math.floor(g.wave * g.wave / 40)) * 4;
+            // L2 base HP: substantially higher than L1 (×6).
+            const rawHp = (CONFIG.ENEMY_HP + g.wave + Math.floor(g.wave * g.wave / 40)) * 6;
             const baseHp = Math.ceil(rawHp * af * earlyMult);
 
             // L2 type weights: capybara-split 50%, engineer-shield 30%, cow-gun 20%


### PR DESCRIPTION
## Summary
After #130 L1 feels appropriate, but L2 mobs still read as too easy. Push the outer multipliers in `spawnEnemyWaveL2`:

- HP outer multiplier `× 4` → `× 6` (+50%)
- DMG outer multiplier `× 3` → `× 5` (+67%)

Applied uniformly to all three L2 mob types — capybara split-on-death, pig-engineer-shield, cow-gun. Type-specific multipliers (hpTypeMult / dmgTypeMult) stay untouched so the relative threat balance between types holds.

L1 spawner unchanged. L2 bosses (CowCry, Elephant) keep their own scaling formulas — if they also feel too soft after this, that's a follow-up PR.

Cache-buster `v=37` → `v=38`.

## Test plan
- [ ] Hard-refresh, play L1: difficulty unchanged from previous tuning.
- [ ] Start L2 with default loadout (just L1 cleared): wave 1-3 enemies clearly take more shots, deal noticeably more damage on contact.
- [ ] Reach wave 5 (CowCry boss): regular mobs feel meaningfully tougher than L1 wave 5 — but the boss itself keeps its current stats (separate PR if needed).
- [ ] Wave 8-10 with shield + frenzy: shield uptime feels valuable, frenzy bursts make a real dent.

Closes #133