### PR TITLE
Fix tutorial reward charge farming, Closes #140

### DIFF
--- a/docs/js/tutorial.js
+++ b/docs/js/tutorial.js
@@ -66,6 +66,8 @@ function setupTutorialRun(g) {
     g.tutorialGoalTimer = 0;
     g.tutorialStepStart = {};
     g.tutorialCamMult = 0;
+    // Keep tutorial-only consumable rewards isolated from the real save.
+    g.tutorialSavedWeaponCharges = { ...(playerData.weaponCharges || {}) };
     g.squadCount = 12;
     g.peakSquad = 12;
     // Prevent the normal random gate spawner from firing during the tutorial.
@@ -196,10 +198,15 @@ function _tutorialGrantCharge(key) {
     if (!playerData.weaponCharges) playerData.weaponCharges = {};
     playerData.weaponCharges[key] = (playerData.weaponCharges[key] || 0) + 1;
     if (key === 'invincibility') game.skillReady = true;
-    savePlayerData(playerData);
     // Don't touch #weaponSlots (the DOM inventory panel) — the canvas
     // drawSkillHud() already reflects charge changes automatically, and
     // opening both stacks two HUDs on the top-left corner.
+}
+
+function restoreTutorialWeaponCharges() {
+    const g = game;
+    if (!g || !g.isTutorial) return;
+    playerData.weaponCharges = { ...(g.tutorialSavedWeaponCharges || {}) };
 }
 
 function _checkStepGoal(step) {
@@ -289,6 +296,7 @@ function completeTutorial() {
     if (!g) return;
     g.state = 'gameover';
     stopBGM();
+    restoreTutorialWeaponCharges();
     playerData.hasSeenTutorial = true;
     markPlayerDataDirty();
     flushPlayerDataSave(true);

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -23,6 +23,11 @@ function resumeGame() {
 
 function restartFromPause() {
     hidePauseMenu();
+    if (game && game.isTutorial) {
+        restoreTutorialWeaponCharges();
+        startGame(0);
+        return;
+    }
     startGameWithLevel(game ? (game.currentLevel || 1) : 1);
 }
 
@@ -30,12 +35,15 @@ function menuFromPause() {
     hidePauseMenu();
     stopBGM();
     if (game) {
+        if (game.isTutorial) restoreTutorialWeaponCharges();
         playerData.level = game.level;
         playerData.exp = game.exp;
         flushPlayerDataSave(true);
         savePlayerData(playerData);
-        saveHighScore(game.score, game.wave);
-        syncHighScore();
+        if (!game.isTutorial) {
+            saveHighScore(game.score, game.wave);
+            syncHighScore();
+        }
     }
     const slotsDiv = document.getElementById('weaponSlots');
     if (slotsDiv) slotsDiv.style.display = 'none';
@@ -267,7 +275,7 @@ function activateInvincibility() {
     if (charges <= 0) return;
     const shopW = SHOP_WEAPONS['invincibility'];
     playerData.weaponCharges['invincibility'] = charges - 1;
-    savePlayerData(playerData);
+    if (!g.isTutorial) savePlayerData(playerData);
     g.shieldActive = true;
     g.shieldTimer = shopW.duration * 1000;
     g.skillCooldown = SKILL_SHARED_COOLDOWN * 1000;
@@ -287,7 +295,7 @@ function activateStimulant() {
     if (charges <= 0) return;
     const shopW = SHOP_WEAPONS['stimulant'];
     playerData.weaponCharges['stimulant'] = charges - 1;
-    savePlayerData(playerData);
+    if (!g.isTutorial) savePlayerData(playerData);
     g.stimulantActive = true;
     g.stimulantTimer = shopW.duration * 1000;
     g.stimulantCooldown = 0;
@@ -517,6 +525,7 @@ function showGameOver() {
     // Tutorial: don't treat death as a "game over" — quietly restart the
     // tutorial from wave 1 so the player can keep learning.
     if (game && game.isTutorial) {
+        restoreTutorialWeaponCharges();
         const slotsDiv = document.getElementById('weaponSlots');
         if (slotsDiv) slotsDiv.style.display = 'none';
         startGame(0);


### PR DESCRIPTION
## Summary

This PR fixes Issue #140 by isolating tutorial-only consumable charges from the normal save file.

Previously, tutorial reward charges could be written directly into `playerData.weaponCharges` and persist beyond the tutorial, allowing shield/frenzy rewards to be farmed into normal gameplay.

Closes #140

## What Changed

- snapshot the real `weaponCharges` when a tutorial run starts
- stop saving tutorial-granted consumable charges directly into the persistent save
- restore the original charge snapshot when:
  - restarting the tutorial from pause
  - exiting the tutorial from the pause menu
  - dying and restarting the tutorial
  - completing the tutorial
- skip persistent charge saves when shield/frenzy is used during the tutorial

## Files Changed

- `docs/js/tutorial.js`
- `docs/js/ui.js`

## Testing

Manual verification target:

1. Start the tutorial.
2. Reach the shield/frenzy reward steps.
3. Use or receive tutorial charges.
4. Exit, restart, die, or complete the tutorial.
5. Confirm normal saved `weaponCharges` remain unchanged outside the tutorial.
