### PR TITLE
Fix: Make in-game HUD and Game Over screen translatable

### DIFF
--- a/docs/js/hud.js
+++ b/docs/js/hud.js
@@ -82,12 +82,12 @@ function updateHUD() {
     rect(panelX + xpBarPad, xpBarY, xpBarW, xpBarH, 3);
 
     // Text: score (center), squad (left), wave (right)
-    _hudText('SCORE: ' + g.score, screenW / 2, 17, 19, 0xffffff);
-    const squadStr = g.stimulantActive ? `SQUAD: ${g.squadCount * 2} x2` : `SQUAD: ${g.squadCount}`;
+    _hudText(T('hud.score') + g.score, screenW / 2, 17, 19, 0xffffff);
+    const squadStr = g.stimulantActive ? `${T('hud.squad')}${g.squadCount * 2} x2` : `${T('hud.squad')}${g.squadCount}`;
     _hudText(squadStr, screenW / 2 - hs, 17, 18, g.stimulantActive ? 0x44ff88 : 0xffffff);
     const maxWaves = g.isTutorial ? TUTORIAL_MAX_WAVE
         : (g.currentLevel === 2 ? MAX_WAVES_LEVEL2 : MAX_WAVES_LEVEL1);
-    _hudText(`WAVE: ${g.wave} / ${maxWaves}`, screenW / 2 + hs, 17, 18, 0xffffff);
+    _hudText(`${T('hud.wave')}${g.wave} / ${maxWaves}`, screenW / 2 + hs, 17, 18, 0xffffff);
 
     // Coins
     _hudText(`\u{1FA99} ${playerData.coins}`, screenW / 2 + hs, 48, 14, 0xffd700, CENTER, false);
@@ -95,7 +95,7 @@ function updateHUD() {
     _hudText(`\u{1F48E} ${playerData.gems || 0}`, screenW / 2 - hs, 48, 14, 0xcc44ff, CENTER, false);
     // Level
     const isMax = g.level >= LEVEL_CONFIG.maxLevel;
-    _hudText(isMax ? '\u2B50 MAX' : `\u2B50 Lv.${g.level}`, screenW / 2, 48, 13, isMax ? 0xffd700 : 0x88ffcc, CENTER, false);
+    _hudText(isMax ? `\u2B50 ${T('hud.max')}` : `\u2B50 ${T('hud.lv')}${g.level}`, screenW / 2, 48, 13, isMax ? 0xffd700 : 0x88ffcc, CENTER, false);
 
     // Weapon timer bar
     const hasGateWeapon = g.weapon !== 'pistol' && g.weaponTimer > 0;
@@ -222,7 +222,7 @@ function drawSkillHud() {
 
         // State label bottom-left
         if (!isReady) {
-            const stateStr = isActive ? 'ACTIVE' : isOnCD ? 'COOLDOWN' : 'NO CHARGE';
+            const stateStr = isActive ? T('hud.skill.active') : isOnCD ? T('hud.skill.cd') : T('hud.skill.empty');
             const stateColor = isActive ? sk.color : isOnCD ? 0x667788 : 0x334455;
             _hudText(stateStr, sx + 5, sy + 37, 9, stateColor, LEFT, false, false);
         }
@@ -520,7 +520,7 @@ function drawLevelUpAnim() {
 
     textSize(Math.floor(20 * sc)); textStyle(BOLD);
     hexFill(0x88ffcc, Math.floor(alpha * 255)); noStroke();
-    text('LEVEL  UP', cx, cy - 18 * sc);
+    text(T('hud.levelup'), cx, cy - 18 * sc);
 
     drawingContext.shadowColor = `rgba(255,215,0,${0.5 * alpha})`;
     drawingContext.shadowBlur = 14;

--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -63,6 +63,11 @@ function applyLang() {
         }
     }
 
+    // If Game Over is open, re-render it
+    if (document.getElementById('scoreDisplay')) {
+        if (typeof renderGameOver === 'function') renderGameOver();
+    }
+
     // data-i18n loop above already handles the main menu elements.
 }
 
@@ -214,6 +219,15 @@ const TRANSLATIONS = {
         'hud.current.weapon.temp': '临时',
         'hud.panel.show':       '显示武器面板',
         'hud.panel.hide':       '收起武器面板',
+        'hud.score':            '得分: ',
+        'hud.squad':            '兵力: ',
+        'hud.wave':             '波次: ',
+        'hud.lv':               'Lv.',
+        'hud.max':              'MAX',
+        'hud.skill.active':     '已激活',
+        'hud.skill.cd':         '冷却中',
+        'hud.skill.empty':      '无充能',
+        'hud.levelup':          '升级',
 
         // Weapon names & descriptions
         'weapon.shotgun.name':        '霰弹枪',
@@ -481,9 +495,15 @@ const TRANSLATIONS = {
         'hud.current.weapon.temp': 'TEMP',
         'hud.panel.show':       'Show weapon panel',
         'hud.panel.hide':       'Hide weapon panel',
-
-        // Weapon names & descriptions
-        'weapon.shotgun.name':        'Shotgun',
+        'hud.score':            'SCORE: ',
+        'hud.squad':            'SQUAD: ',
+        'hud.wave':             'WAVE: ',
+        'hud.lv':               'Lv.',
+        'hud.max':              'MAX',
+        'hud.skill.active':     'ACTIVE',
+        'hud.skill.cd':         'COOLDOWN',
+        'hud.skill.empty':      'NO CHARGE',
+        'hud.levelup':          'LEVEL UP',
         'weapon.shotgun.desc':        'Spread fire, deadly at close range',
         'weapon.shotgun.lv1':         'Strong up close, weak at range',
         'weapon.shotgun.lv2':         'Dmg ×1.6, +2 pellets',

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -624,6 +624,18 @@ function showGameOver() {
     document.getElementById('midShopOverlay').classList.add('hidden');
     const slotsDiv = document.getElementById('weaponSlots');
     if (slotsDiv) slotsDiv.style.display = 'none';
+
+    game._isNewRecord = isNewRecord;
+    game._hs = hs;
+    renderGameOver();
+}
+
+function renderGameOver() {
+    if (!game) return;
+    const currentLvl = game.currentLevel || 1;
+    const isNewRecord = game._isNewRecord;
+    const hs = game._hs;
+    
     overlay.innerHTML = `
         <h1>${T('gameover.title')}</h1>
         <div id="scoreDisplay">${T('gameover.score')}</div>


### PR DESCRIPTION
This PR fixes a bug where the language of the in-game HUD and Game Over screen did not update when toggling the language during gameplay.

**Changes:**
- Added HUD and Skill translations to `i18n.js`.
- Updated `hud.js` to use `T(...)` dynamically every frame instead of hardcoding English strings for Score, Squad, Wave, and Level up text.
- Extracted Game Over screen HTML rendering to `renderGameOver` and called it from `applyLang()` to update the Game Over screen instantly if visible.