### PR TITLE
Fix tutorial EXP progression leak, Closes #147

### DIFF
--- a/docs/js/combat.js
+++ b/docs/js/combat.js
@@ -308,7 +308,7 @@ function checkLevelUp(g, bigEffect) {
 
 // Award XP for regular enemy kills — scales with wave
 function awardKillXP(g, isHeavy) {
-    if (!g || g.level >= LEVEL_CONFIG.maxLevel) return;
+    if (!g || g.isTutorial || g.level >= LEVEL_CONFIG.maxLevel) return;
     const kc = LEVEL_CONFIG.killXp;
     const step = Math.floor(g.wave / kc.wavePerStep);
     const baseXp = kc.base + Math.floor(Math.pow(step, kc.exp));
@@ -321,7 +321,7 @@ function awardKillXP(g, isHeavy) {
 
 function awardBossExp(isMegaBoss, x, z) {
     const g = game;
-    if (!g || g.level >= LEVEL_CONFIG.maxLevel) return;
+    if (!g || g.isTutorial || g.level >= LEVEL_CONFIG.maxLevel) return;
 
     // ── Normal-distribution XP roll (exponential scaling) ──
     const cfg = LEVEL_CONFIG.bossXp;


### PR DESCRIPTION
## Summary

This PR fixes Issue #147 by preventing tutorial enemy kills and tutorial mini boss kills from granting permanent EXP or level progress.

Previously, tutorial combat still used the normal reward path, so kills could update `playerData.exp` and trigger level-up persistence even though tutorial runs should be isolated from normal progression.

Closes #147

## What Changed

- updated regular enemy kill EXP rewards to skip tutorial runs
- updated boss EXP rewards to skip tutorial runs
- kept normal Level 1 and Level 2 progression behavior unchanged

## Files Changed

- `docs/js/combat.js`

## Testing

Manual/code verification:

1. Confirmed `awardKillXP(...)` now returns early when `g.isTutorial` is true.
2. Confirmed `awardBossExp(...)` now returns early when `g.isTutorial` is true.
3. Confirmed the change only affects tutorial runs and does not change normal non-tutorial EXP logic.

Note: `node --check` could not be run locally because `node.exe` was blocked with `Access denied` on this machine.
