### PR TITLE
Fix mid-shop language refresh, Closes #149

### DIFF
--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -48,7 +48,11 @@ function applyLang() {
         if (typeof renderShop === 'function') renderShop();
     }
 
-    // Mid-shop: title/subtitle/button are data-i18n handled above
+    // Mid-shop dynamic stats/options are rendered strings, so refresh them too.
+    const midShopEl = document.getElementById('midShopOverlay');
+    if (midShopEl && !midShopEl.classList.contains('hidden')) {
+        if (typeof renderMidShop === 'function') renderMidShop();
+    }
 
     // If leaderboard is open, re-render it
     const lbEl = document.getElementById('leaderboardOverlay');


### PR DESCRIPTION
## Summary

This PR fixes Issue #149 by refreshing the mid-game supply shop dynamic content when the language is toggled.

Previously, static `data-i18n` text updated correctly, but dynamic content rendered by `renderMidShop()` could stay in the previous language.

Closes #149

## What Changed

- Detects when `#midShopOverlay` is visible during `applyLang()`
- Re-renders `renderMidShop()` so stats and supply options update immediately
- Keeps existing normal shop and leaderboard refresh behavior unchanged

## Testing

Manual/code verification:

1. Confirmed normal shop refresh logic is unchanged.
2. Confirmed visible mid-shop overlay now triggers `renderMidShop()` on language toggle.
3. Confirmed the change is limited to `docs/js/i18n.js`.
