### PR TITLE
Fix tutorial currency pickup farming, Closes #151

### DIFF
--- a/docs/js/update_world.js
+++ b/docs/js/update_world.js
@@ -197,9 +197,11 @@ function updateWorld(g, dt, dtF, bossAlive) {
         if (dist < 25) {
             coin.collected = true;
             g.coinsCollected += coin.value;
-            playerData.coins += coin.value;
-            addStat('totalCoinsEarned', coin.value);
-            markPlayerDataDirty();
+            if (!g.isTutorial) {
+                playerData.coins += coin.value;
+                addStat('totalCoinsEarned', coin.value);
+                markPlayerDataDirty();
+            }
             // Pickup effect — golden burst with speed lines
             const cp = project(coin.x, coin.z - g.cameraZ);
             addScorePopup(`🪙+${coin.value}`, cp.x, cp.y - 20, 0xffd700);
@@ -244,9 +246,11 @@ function updateWorld(g, dt, dtF, bossAlive) {
         if (gdist < 25) {
             gem.collected = true;
             g.gemsCollected += gem.value;
-            playerData.gems = (playerData.gems || 0) + gem.value;
-            addStat('totalGemsEarned', gem.value);
-            markPlayerDataDirty();
+            if (!g.isTutorial) {
+                playerData.gems = (playerData.gems || 0) + gem.value;
+                addStat('totalGemsEarned', gem.value);
+                markPlayerDataDirty();
+            }
             // Pickup effect — purple explosion with blast ring + speed lines
             const gp = project(gem.x, gem.z - g.cameraZ);
             addScorePopup(`💎+${gem.value}`, gp.x, gp.y - 25, 0xcc44ff);


### PR DESCRIPTION
## Summary

This PR fixes Issue #151 by preventing tutorial coin and gem pickups from being saved into permanent player currency.

Tutorial pickups still count toward tutorial-local objectives, but they no longer update `playerData.coins`, `playerData.gems`, or permanent collection achievement stats.

Closes #151

## What Changed

- Kept `g.coinsCollected` updates for tutorial coin objectives
- Kept `g.gemsCollected` updates for tutorial gem objectives
- Skipped permanent coin/gem save writes during tutorial mode
- Skipped permanent collection achievement stat updates during tutorial mode

## Testing

Manual/code verification:

1. Confirmed tutorial coin pickups still increment `g.coinsCollected`.
2. Confirmed tutorial gem pickups still increment `g.gemsCollected`.
3. Confirmed permanent `playerData.coins/gems` writes are guarded by `!g.isTutorial`.
4. Confirmed normal Level 1 and Level 2 pickups still use the existing save/stat path.
