### PR TITLE
Skip global hotkeys while a text field is focused, Closes #158

### DIFF
--- a/docs/js/input.js
+++ b/docs/js/input.js
@@ -7,7 +7,20 @@ function setupInput() {
         Object.keys(keys).forEach(k => { keys[k] = false; });
     };
 
+    // While the player is typing in a text field (e.g. the leaderboard
+    // join name input), we must NOT intercept space / Esc / 1 / 2 / etc.
+    // — preventDefault on space would otherwise stop the space character
+    // from reaching the input.
+    const _isTypingTarget = (el) => {
+        if (!el) return false;
+        const tag = el.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+        if (el.isContentEditable) return true;
+        return false;
+    };
+
     document.addEventListener('keydown', (e) => {
+        if (_isTypingTarget(e.target)) return;
         keys[e.key] = true;
         if (e.key === 'Escape' || e.key === 'p' || e.key === 'P') {
             if (game) {


### PR DESCRIPTION
## Summary
Open issue #158: typing in the leaderboard join form is broken because the global `keydown` handler in `input.js` intercepts every key:

- **Space** — `e.preventDefault()` blocks the character from reaching `<input>` (line 23). Players can't type names with spaces.
- **Esc / p / P** — would toggle pause if a game were running. Currently no-op on the menu but still wrong scope.
- **1 / 2** — fires `activateInvincibility` / `activateStimulant`. No-op without a game, but still pollutes the focus context.

## Fix
Add an `_isTypingTarget(e.target)` guard at the top of the keydown handler. Short-circuit when the target is `INPUT`, `TEXTAREA`, `SELECT`, or `contentEditable`. Typing in any text field then behaves like a normal text field.

Gameplay never overlaps a focused text field (you can't fight while the leaderboard overlay is up), so the early return doesn't suppress any in-game input.

## Test plan
- [ ] Open Leaderboard → click "Join" → type a name with spaces. Spaces appear in the input.
- [ ] Type `p` / `Esc` / `1` / `2` inside the input — characters appear (where the key produces one) and no pause / skill side-effects fire.
- [ ] Close leaderboard, start a level: spacebar still triggers skill weapon, Esc still pauses, 1/2 still trigger shield/frenzy.

Closes #158