### PR TITLE
Fix global hotkeys while typing leaderboard names, Closes #158

### DIFF
--- a/docs/js/input.js
+++ b/docs/js/input.js
@@ -2,12 +2,24 @@
 // INPUT — keyboard, mouse, touch handling
 // ============================================================
 
+function isTextEntryTarget(target) {
+    if (!target) return false;
+    const tag = target.tagName;
+    if (tag === 'TEXTAREA' || target.isContentEditable) return true;
+    if (tag !== 'INPUT') return false;
+
+    const type = (target.type || 'text').toLowerCase();
+    return !['button', 'checkbox', 'radio', 'range', 'reset', 'submit'].includes(type);
+}
+
 function setupInput() {
     const clearKeys = () => {
         Object.keys(keys).forEach(k => { keys[k] = false; });
     };
 
     document.addEventListener('keydown', (e) => {
+        if (isTextEntryTarget(e.target)) return;
+
         keys[e.key] = true;
         if (e.key === 'Escape' || e.key === 'p' || e.key === 'P') {
             if (game) {


### PR DESCRIPTION
## Summary

This PR fixes Issue #158 by preventing global gameplay hotkeys from running while the user is typing in text-entry UI.

Previously, the document-level Space hotkey called `preventDefault()`, so leaderboard names like `Blue Cat` could not be entered.

## What Changed

- added a small `isTextEntryTarget()` helper
- skipped global keydown gameplay shortcuts for input, textarea, and content-editable targets
- preserved normal gameplay hotkeys outside text-entry fields

Closes #158

## Testing

- Ran `git diff --check`
- Verified the PR diff only changes `docs/js/input.js`

Note: `node --check docs/js/input.js` could not run because this Windows environment returns `Access denied` for `node.exe`.
