### PR TITLE
Cap four uncapped effect arrays in update_effects.js, Closes #161

### DIFF
--- a/docs/js/update_effects.js
+++ b/docs/js/update_effects.js
@@ -72,10 +72,12 @@ function updateEffects(g, dt, dtF) {
         p.life -= dtF;
     });
     g.gateCollapsePanels = g.gateCollapsePanels.filter(p => p.life > 0);
+    if (g.gateCollapsePanels.length > 60) g.gateCollapsePanels.splice(0, g.gateCollapsePanels.length - 40);
 
     // Speed lines
     g.speedLines.forEach(s => { s.x += s.vx * dtF; s.y += s.vy * dtF; s.life -= dtF; });
     g.speedLines = g.speedLines.filter(s => s.life > 0);
+    if (g.speedLines.length > 200) g.speedLines.splice(0, g.speedLines.length - 140);
 
     // Gate flash
     if (g.gateFlash) {
@@ -90,6 +92,7 @@ function updateEffects(g, dt, dtF) {
         t.y -= 1.5 * dtF;
     });
     g.barrelExplosionTexts = g.barrelExplosionTexts.filter(t => t.timer < t.maxTimer);
+    if (g.barrelExplosionTexts.length > 30) g.barrelExplosionTexts.splice(0, g.barrelExplosionTexts.length - 20);
 
     // Damage numbers
     g.damageNumbers.forEach(d => { d.offsetY -= 1.2 * dtF; d.life -= dtF; });
@@ -99,6 +102,7 @@ function updateEffects(g, dt, dtF) {
     // Score popups
     g.scorePopups.forEach(p => { p.y -= 1.5 * dtF; p.life -= dtF; });
     g.scorePopups = g.scorePopups.filter(p => p.life > 0);
+    if (g.scorePopups.length > 60) g.scorePopups.splice(0, g.scorePopups.length - 40);
 
     // Combo timer
     if (g.comboTimer > 0) {


### PR DESCRIPTION
## Summary
`update_effects.js` had a hard cap on `damageNumbers` (line 97) but not on the four other ephemeral effect arrays in the same file. Under sustained combat the missing caps let them grow into the hundreds-to-thousands and stay there until lifetimes expire.

| Array | Triggered by |
|---|---|
| `gateCollapsePanels` | every gate destroyed (multiple panels per gate) |
| `speedLines` | gates, kills, slams, shockwaves |
| `barrelExplosionTexts` | barrel chain reactions |
| `scorePopups` | every kill, combo, dodge, mid-shop buy |

Added the same `splice(0, len - keep)` pattern that `damageNumbers` already uses. Caps chosen so normal waves don't trip them but a mega-boss death cascade or multi-barrel chain gets clipped:

| Array | Cap | Keep |
|---|---|---|
| `gateCollapsePanels` | 60 | 40 |
| `speedLines` | 200 | 140 |
| `barrelExplosionTexts` | 30 | 20 |
| `scorePopups` | 60 | 40 |

Drops oldest entries first, so the newest on-screen visuals are preserved.

## Test plan
- [ ] Normal wave 1-5: visual feedback unchanged.
- [ ] Boss wave with AOE rocket: extreme particle bursts no longer slow the frame rate down on a sustained basis.
- [ ] Multi-barrel chain (drop a rocket on a 5-barrel cluster): no visible regression in the burst, just no lingering stale text.

Closes #161