### PR TITLE
Clamp gate / barrel floating text size and drop gate text below boss HUD band, Closes #164

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
 <link rel="icon" type="image/png" href="assets/favicon.png">
-<link rel="stylesheet" href="style.css?v=20">
+<link rel="stylesheet" href="style.css?v=21">
 <style>
 /* p5.js canvas sits behind all overlays.
    Use "body > canvas" to target only the p5 canvas (direct child of body),
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=38"></script>
-<script src="js/config.js?v=38"></script>
-<script src="js/i18n.js?v=38"></script>
-<script src="js/globals.js?v=38"></script>
-<script src="js/audio.js?v=38"></script>
-<script src="js/core.js?v=38"></script>
-<script src="js/helpers.js?v=38"></script>
-<script src="js/spawn.js?v=38"></script>
-<script src="js/combat.js?v=38"></script>
+<script src="js/crypto.js?v=39"></script>
+<script src="js/config.js?v=39"></script>
+<script src="js/i18n.js?v=39"></script>
+<script src="js/globals.js?v=39"></script>
+<script src="js/audio.js?v=39"></script>
+<script src="js/core.js?v=39"></script>
+<script src="js/helpers.js?v=39"></script>
+<script src="js/spawn.js?v=39"></script>
+<script src="js/combat.js?v=39"></script>
 <script src="js/draw.js?v=40"></script>
-<script src="js/hud.js?v=38"></script>
-<script src="js/update_timers.js?v=38"></script>
-<script src="js/update_collision.js?v=38"></script>
-<script src="js/update_enemies.js?v=38"></script>
-<script src="js/update_world.js?v=38"></script>
-<script src="js/update_effects.js?v=38"></script>
-<script src="js/update.js?v=38"></script>
+<script src="js/hud.js?v=39"></script>
+<script src="js/update_timers.js?v=39"></script>
+<script src="js/update_collision.js?v=39"></script>
+<script src="js/update_enemies.js?v=39"></script>
+<script src="js/update_world.js?v=39"></script>
+<script src="js/update_effects.js?v=39"></script>
+<script src="js/update.js?v=39"></script>
 <script src="js/render.js?v=39"></script>
-<script src="js/achievements.js?v=38"></script>
-<script src="js/shop.js?v=38"></script>
-<script src="js/leaderboard.js?v=38"></script>
-<script src="js/input.js?v=38"></script>
-<script src="js/ui.js?v=38"></script>
-<script src="js/tutorial.js?v=38"></script>
+<script src="js/achievements.js?v=39"></script>
+<script src="js/shop.js?v=39"></script>
+<script src="js/leaderboard.js?v=39"></script>
+<script src="js/input.js?v=39"></script>
+<script src="js/ui.js?v=39"></script>
+<script src="js/tutorial.js?v=39"></script>
 <script src="js/main.js?v=39"></script>
 </body>
 </html>

--- a/docs/js/draw.js
+++ b/docs/js/draw.js
@@ -1164,10 +1164,15 @@ function drawGateFloatingText() {
     const t = g.gateText;
     const progress = t.timer / t.maxTimer;
     const a = progress > 0.6 ? 1 - (progress - 0.6) / 0.4 : 1;
-    const yPos = screenH * 0.35 - progress * 40;
+    // Sit over the road plate, not over the boss HP bar / wave banner that
+    // now share the upper half with the new level backdrops.
+    const yPos = screenH * 0.52 - progress * 40;
     push();
     textFont('Arial');
-    textSize(Math.floor(42 * t.scale));
+    // Cap peak font size so "-3 TROOPS" etc. don't span half the screen on
+    // wide displays. t.scale ramps to 1.8 in update_effects.js, which gave
+    // 76px before the cap.
+    textSize(Math.min(54, Math.floor(42 * t.scale)));
     textStyle(BOLD);
     textAlign(CENTER, CENTER);
     // Shadow
@@ -1190,7 +1195,9 @@ function drawBarrelExplosionTexts() {
         if (a <= 0) return;
         push();
         textFont('Arial');
-        textSize(Math.floor(36 * t.scale));
+        // Cap peak font size — t.scale ramps to 2.2 in update_effects.js,
+        // which produced ~79px without a clamp.
+        textSize(Math.min(48, Math.floor(36 * t.scale)));
         textStyle(BOLD);
         textAlign(CENTER, CENTER);
         hexFill(0x000000, Math.floor(a * 0.5 * 255)); noStroke();


### PR DESCRIPTION
## Summary
After the new level backgrounds landed (c1e70bd), the upper half of the play area now carries the city/horizon skyline along with the existing boss HP bar (`drawBossHud` y≈92) and wave banner (`drawWaveBanner` y=`screenH*0.22`). The gate floating text `-3 TROOPS` / `+5 TROOPS` / `GROUND SLAM` etc. was sitting at `screenH*0.35` and used an uncapped `textSize(42 * t.scale)` (scale ramps to 1.8) → 76 px peak regardless of viewport. On a 1920+ window the text spanned ~40 % of screen width and visually collided with the boss HP bar — confirmed in user screenshot.

Same shape for barrel-explosion text: `textSize(36 * t.scale)` × 2.2 → 79 px peak.

## Fix (`draw.js`)
- `drawGateFloatingText` text size → `Math.min(54, Math.floor(42 * t.scale))`
- `drawBarrelExplosionTexts` text size → `Math.min(48, Math.floor(36 * t.scale))`
- `drawGateFloatingText` yPos → `screenH * 0.52` (was 0.35), putting the popup over the road plate instead of over the boss HUD band.

Animation curve, color, lifetime, shadow all unchanged. Behavior on small screens is preserved (floats already capped naturally below the new ceiling).

Cache-buster bumped `?v=38 → v=39` and `style.css?v=20 → v=21`.

## Test plan
- [ ] Hard-refresh, walk through a +/-troops gate on L1: popup is clearly readable but no longer dominates the screen, and sits over the road instead of the boss/wave area.
- [ ] Trigger a Boss-wave with active boss HP bar visible: `+5 TROOPS` popup no longer collides with the bar.
- [ ] Detonate a barrel chain: `KABOOM!` text scales but caps before overflowing.
- [ ] On a small window (≤900 px wide): no regression — sizes stay near the same as before.

Closes #164