### PR TITLE
Catch localStorage.setItem quota errors in _signedSave, Closes #166

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=39"></script>
-<script src="js/config.js?v=39"></script>
-<script src="js/i18n.js?v=39"></script>
-<script src="js/globals.js?v=39"></script>
-<script src="js/audio.js?v=39"></script>
-<script src="js/core.js?v=39"></script>
-<script src="js/helpers.js?v=39"></script>
-<script src="js/spawn.js?v=39"></script>
-<script src="js/combat.js?v=39"></script>
+<script src="js/crypto.js?v=40"></script>
+<script src="js/config.js?v=40"></script>
+<script src="js/i18n.js?v=40"></script>
+<script src="js/globals.js?v=40"></script>
+<script src="js/audio.js?v=40"></script>
+<script src="js/core.js?v=40"></script>
+<script src="js/helpers.js?v=40"></script>
+<script src="js/spawn.js?v=40"></script>
+<script src="js/combat.js?v=40"></script>
 <script src="js/draw.js?v=40"></script>
-<script src="js/hud.js?v=39"></script>
-<script src="js/update_timers.js?v=39"></script>
-<script src="js/update_collision.js?v=39"></script>
-<script src="js/update_enemies.js?v=39"></script>
-<script src="js/update_world.js?v=39"></script>
-<script src="js/update_effects.js?v=39"></script>
-<script src="js/update.js?v=39"></script>
-<script src="js/render.js?v=39"></script>
-<script src="js/achievements.js?v=39"></script>
-<script src="js/shop.js?v=39"></script>
-<script src="js/leaderboard.js?v=39"></script>
-<script src="js/input.js?v=39"></script>
-<script src="js/ui.js?v=39"></script>
-<script src="js/tutorial.js?v=39"></script>
-<script src="js/main.js?v=39"></script>
+<script src="js/hud.js?v=40"></script>
+<script src="js/update_timers.js?v=40"></script>
+<script src="js/update_collision.js?v=40"></script>
+<script src="js/update_enemies.js?v=40"></script>
+<script src="js/update_world.js?v=40"></script>
+<script src="js/update_effects.js?v=40"></script>
+<script src="js/update.js?v=40"></script>
+<script src="js/render.js?v=40"></script>
+<script src="js/achievements.js?v=40"></script>
+<script src="js/shop.js?v=40"></script>
+<script src="js/leaderboard.js?v=40"></script>
+<script src="js/input.js?v=40"></script>
+<script src="js/ui.js?v=40"></script>
+<script src="js/tutorial.js?v=40"></script>
+<script src="js/main.js?v=40"></script>
 </body>
 </html>

--- a/docs/js/crypto.js
+++ b/docs/js/crypto.js
@@ -53,7 +53,14 @@ _s0=function(sk,data){
     obj['\x63']=sig.substring(0,16); // checksum part 1
     obj['\x6e']=_h(ts.toString(36)+enc.substring(0,20)).substring(0,12); // noise (derived, verifiable)
     obj['\x78']=sig.substring(16);   // checksum part 2
-    localStorage.setItem(sk,JSON.stringify(obj));
+    try{
+        localStorage.setItem(sk,JSON.stringify(obj));
+    }catch(e){
+        // Quota exceeded (Safari iOS private mode = 0 quota) or storage
+        // disabled — surface a single warning instead of letting the throw
+        // abort the caller (level-clear / boss-kill save flushes, etc.).
+        try{console.warn('save failed:',e&&e.name);}catch(_){}
+    }
 };
 
 _s1=function(sk){


### PR DESCRIPTION
## Summary
`crypto.js _s0` wrote the encrypted save payload to localStorage without a try/catch. Browsers throw `QuotaExceededError` when the per-origin quota fills, and **Safari iOS private mode has a 0-byte quota** — every save throws, the throw bubbles up through `_signedSave → savePlayerData → flushPlayerDataSave` and aborts whatever caller triggered it (boss kill, level clear, mid-shop buy, achievement claim, …). The user has no signal that their run was lost.

## Fix
Wrap the `setItem` call in try/catch. On failure log a single `console.warn` so a user with DevTools open can see why their progression silently reverted, and let the caller continue. The load path `_s1` already swallows `JSON.parse` errors gracefully, so the read side is already symmetric.

Cache-buster bumped `?v=39 → v=40`.

## Test plan
- [ ] Normal play: saves still write, no behaviour change.
- [ ] Open Safari in Private mode (or fill localStorage to quota in DevTools), play a wave: no thrown exception in the console; a single `save failed: QuotaExceededError` warning is logged.
- [ ] Boss kill / mid-shop buy in that condition: gameplay continues, no run-aborting throw.

Closes #166