### PR TITLE
Flush pending save when the page hides / unloads, Closes #168

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=40"></script>
-<script src="js/config.js?v=40"></script>
-<script src="js/i18n.js?v=40"></script>
-<script src="js/globals.js?v=40"></script>
-<script src="js/audio.js?v=40"></script>
-<script src="js/core.js?v=40"></script>
-<script src="js/helpers.js?v=40"></script>
-<script src="js/spawn.js?v=40"></script>
-<script src="js/combat.js?v=40"></script>
-<script src="js/draw.js?v=40"></script>
-<script src="js/hud.js?v=40"></script>
-<script src="js/update_timers.js?v=40"></script>
-<script src="js/update_collision.js?v=40"></script>
-<script src="js/update_enemies.js?v=40"></script>
-<script src="js/update_world.js?v=40"></script>
-<script src="js/update_effects.js?v=40"></script>
-<script src="js/update.js?v=40"></script>
-<script src="js/render.js?v=40"></script>
-<script src="js/achievements.js?v=40"></script>
-<script src="js/shop.js?v=40"></script>
-<script src="js/leaderboard.js?v=40"></script>
-<script src="js/input.js?v=40"></script>
-<script src="js/ui.js?v=40"></script>
-<script src="js/tutorial.js?v=40"></script>
-<script src="js/main.js?v=40"></script>
+<script src="js/crypto.js?v=41"></script>
+<script src="js/config.js?v=41"></script>
+<script src="js/i18n.js?v=41"></script>
+<script src="js/globals.js?v=41"></script>
+<script src="js/audio.js?v=41"></script>
+<script src="js/core.js?v=41"></script>
+<script src="js/helpers.js?v=41"></script>
+<script src="js/spawn.js?v=41"></script>
+<script src="js/combat.js?v=41"></script>
+<script src="js/draw.js?v=41"></script>
+<script src="js/hud.js?v=41"></script>
+<script src="js/update_timers.js?v=41"></script>
+<script src="js/update_collision.js?v=41"></script>
+<script src="js/update_enemies.js?v=41"></script>
+<script src="js/update_world.js?v=41"></script>
+<script src="js/update_effects.js?v=41"></script>
+<script src="js/update.js?v=41"></script>
+<script src="js/render.js?v=41"></script>
+<script src="js/achievements.js?v=41"></script>
+<script src="js/shop.js?v=41"></script>
+<script src="js/leaderboard.js?v=41"></script>
+<script src="js/input.js?v=41"></script>
+<script src="js/ui.js?v=41"></script>
+<script src="js/tutorial.js?v=41"></script>
+<script src="js/main.js?v=41"></script>
 </body>
 </html>

--- a/docs/js/input.js
+++ b/docs/js/input.js
@@ -48,9 +48,20 @@ function setupInput() {
     });
     document.addEventListener('keyup', (e) => { keys[e.key] = false; });
     window.addEventListener('blur', clearKeys);
+    // Flush any pending save when the page goes to the background or is
+    // about to be unloaded — flushPlayerDataSave is throttled to ~3s
+    // during the normal frame loop, which leaves a window where freshly
+    // earned coins / gems can be lost if the tab is closed quickly.
+    const _flushOnLeave = () => {
+        try { if (typeof flushPlayerDataSave === 'function') flushPlayerDataSave(true); } catch (_) {}
+    };
     document.addEventListener('visibilitychange', () => {
-        if (document.hidden) clearKeys();
+        if (document.hidden) {
+            clearKeys();
+            _flushOnLeave();
+        }
     });
+    window.addEventListener('pagehide', _flushOnLeave);
 
     // Pause button
     const pauseBtn = document.getElementById('pauseBtn');


### PR DESCRIPTION
## Summary
`flushPlayerDataSave` is throttled to write every ~3 seconds during `update()`. The existing `visibilitychange` handler only called `clearKeys()` — players who closed the tab inside the 0-3 s window after picking up coins / gems silently lost that progression.

## Fix
Extend the `visibilitychange` handler to call `flushPlayerDataSave(true)` when the page is hidden, and add a `pagehide` listener for the iOS Safari close path that doesn't always fire `visibilitychange` first.

`flushPlayerDataSave(true)` early-returns when nothing is dirty, so the extra fires are cheap. `_signedSave` was just hardened against `QuotaExceededError` in #167, so flushing on every blur won't surface unhandled exceptions.

Cache-buster bumped `?v=40 → v=41`.

## Test plan
- [ ] Pick up some coins, switch tab via Cmd+Tab, return — DevTools localStorage shows the new `bridgeAssault_playerData` payload includes those coins.
- [ ] Pick up some coins, immediately Cmd+W close the tab, reopen the page — coins persist.
- [ ] On iOS Safari, swipe up to dismiss; reopen — same behaviour.
- [ ] Normal play unaffected (saves still happen at the regular 3 s cadence).

Closes #168