### PR TITLE
Pause hidden main-menu monster animations during gameplay, Closes #170

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
 <link rel="icon" type="image/png" href="assets/favicon.png">
-<link rel="stylesheet" href="style.css?v=21">
+<link rel="stylesheet" href="style.css?v=22">
 <style>
 /* p5.js canvas sits behind all overlays.
    Use "body > canvas" to target only the p5 canvas (direct child of body),

--- a/docs/style.css
+++ b/docs/style.css
@@ -70,6 +70,10 @@ body::after {
     overflow: hidden;
 }
 #overlay.hidden { opacity: 0; pointer-events: none; }
+/* Pause descendant CSS animations (menu monster sprite-steps + floats) so
+   they don't keep ticking on the compositor while the menu is invisible
+   during gameplay. Animations resume from where they paused on un-hide. */
+#overlay.hidden .menu-monster { animation-play-state: paused; }
 #overlay::before,
 #overlay::after {
     content: "";


### PR DESCRIPTION
## Summary
`#overlay.hidden` only set `opacity: 0` + `pointer-events: none`, which makes the menu transparent but doesn't stop CSS animations on its descendants. The six `.menu-monster` decoration layers each ran two infinite animations (sprite-step + float) — **12 always-on CSS animations** continuously ticking on the compositor even though nothing was visible during gameplay.

## Fix
Add a single rule to `docs/style.css`:
```css
#overlay.hidden .menu-monster { animation-play-state: paused; }
```
Animations resume from where they paused on un-hide, so there's no visual jump back to the menu.

style cache-buster bumped `?v=21 → v=22`.

## Test plan
- [ ] Open DevTools → Animations: enter a level, observe the menu-monster animations are paused.
- [ ] Return to menu (game over → main menu): the monsters animate again, smooth, no flicker.
- [ ] L1 / L2 gameplay: visual unchanged, frame-time stays the same or improves marginally on lower-end devices.

Closes #170