### PR TITLE
Fix storage and touch handling edge cases

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
 <link rel="icon" type="image/png" href="assets/favicon.png">
-<link rel="stylesheet" href="style.css?v=22">
+<link rel="stylesheet" href="style.css?v=23">
 <style>
 /* p5.js canvas sits behind all overlays.
    Use "body > canvas" to target only the p5 canvas (direct child of body),
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=41"></script>
-<script src="js/config.js?v=41"></script>
-<script src="js/i18n.js?v=41"></script>
-<script src="js/globals.js?v=41"></script>
-<script src="js/audio.js?v=41"></script>
-<script src="js/core.js?v=41"></script>
-<script src="js/helpers.js?v=41"></script>
-<script src="js/spawn.js?v=41"></script>
-<script src="js/combat.js?v=41"></script>
-<script src="js/draw.js?v=41"></script>
-<script src="js/hud.js?v=41"></script>
-<script src="js/update_timers.js?v=41"></script>
-<script src="js/update_collision.js?v=41"></script>
-<script src="js/update_enemies.js?v=41"></script>
-<script src="js/update_world.js?v=41"></script>
-<script src="js/update_effects.js?v=41"></script>
-<script src="js/update.js?v=41"></script>
-<script src="js/render.js?v=41"></script>
-<script src="js/achievements.js?v=41"></script>
-<script src="js/shop.js?v=41"></script>
-<script src="js/leaderboard.js?v=41"></script>
-<script src="js/input.js?v=41"></script>
-<script src="js/ui.js?v=41"></script>
-<script src="js/tutorial.js?v=41"></script>
-<script src="js/main.js?v=41"></script>
+<script src="js/crypto.js?v=42"></script>
+<script src="js/config.js?v=42"></script>
+<script src="js/i18n.js?v=42"></script>
+<script src="js/globals.js?v=42"></script>
+<script src="js/audio.js?v=42"></script>
+<script src="js/core.js?v=42"></script>
+<script src="js/helpers.js?v=42"></script>
+<script src="js/spawn.js?v=42"></script>
+<script src="js/combat.js?v=42"></script>
+<script src="js/draw.js?v=42"></script>
+<script src="js/hud.js?v=42"></script>
+<script src="js/update_timers.js?v=42"></script>
+<script src="js/update_collision.js?v=42"></script>
+<script src="js/update_enemies.js?v=42"></script>
+<script src="js/update_world.js?v=42"></script>
+<script src="js/update_effects.js?v=42"></script>
+<script src="js/update.js?v=42"></script>
+<script src="js/render.js?v=42"></script>
+<script src="js/achievements.js?v=42"></script>
+<script src="js/shop.js?v=42"></script>
+<script src="js/leaderboard.js?v=42"></script>
+<script src="js/input.js?v=42"></script>
+<script src="js/ui.js?v=42"></script>
+<script src="js/tutorial.js?v=42"></script>
+<script src="js/main.js?v=42"></script>
 </body>
 </html>

--- a/docs/js/globals.js
+++ b/docs/js/globals.js
@@ -61,17 +61,20 @@ const MAIN_MENU_TEMPLATE = overlay ? overlay.innerHTML : '';
 
 const DATA_VERSION = 'v2';
 (function checkDataVersion() {
-    const stored = localStorage.getItem('bridgeAssault_dataVersion');
+    let stored = null;
+    try { stored = localStorage.getItem('bridgeAssault_dataVersion'); } catch (_) { return; }
     if (stored !== DATA_VERSION) {
-        localStorage.setItem('bridgeAssault_dataVersion', DATA_VERSION);
+        try { localStorage.setItem('bridgeAssault_dataVersion', DATA_VERSION); } catch (_) {}
     }
 })();
 
 function resetBridgeAssaultSaveData() {
-    Object.keys(localStorage)
-        .filter(k => k.startsWith('bridgeAssault_'))
-        .forEach(k => localStorage.removeItem(k));
-    localStorage.setItem('bridgeAssault_dataVersion', DATA_VERSION);
+    try {
+        Object.keys(localStorage)
+            .filter(k => k.startsWith('bridgeAssault_'))
+            .forEach(k => localStorage.removeItem(k));
+        localStorage.setItem('bridgeAssault_dataVersion', DATA_VERSION);
+    } catch (_) {}
 }
 
 function loadPlayerData() {

--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -1,7 +1,15 @@
 // ============================================================
 // INTERNATIONALIZATION (i18n)
 // ============================================================
-let LANG = localStorage.getItem('bridgeAssault_lang') || 'en';
+function _safeGetLocalStorage(key) {
+    try { return localStorage.getItem(key); } catch (_) { return null; }
+}
+
+function _safeSetLocalStorage(key, value) {
+    try { localStorage.setItem(key, value); return true; } catch (_) { return false; }
+}
+
+let LANG = _safeGetLocalStorage('bridgeAssault_lang') || 'en';
 
 // T(key, ...args) — look up translation, replace {0} {1} placeholders
 function T(key) {
@@ -14,7 +22,7 @@ function T(key) {
 
 function setLang(lang) {
     LANG = lang;
-    localStorage.setItem('bridgeAssault_lang', lang);
+    _safeSetLocalStorage('bridgeAssault_lang', lang);
     // Update html lang attribute
     document.documentElement.lang = lang;
     applyLang();

--- a/docs/js/input.js
+++ b/docs/js/input.js
@@ -65,6 +65,7 @@ function setupInput() {
 
     // Pause button
     const pauseBtn = document.getElementById('pauseBtn');
+    if (!pauseBtn) return;
     if ('ontouchstart' in window || navigator.maxTouchPoints > 0) {
         pauseBtn.style.display = 'block';
     }
@@ -98,13 +99,15 @@ function mouseMoved() {
 function touchMoved() {
     if (game && game.state === 'playing' && touches.length > 0) {
         game.inputX = Math.max(-CONFIG.ROAD_HALF_WIDTH, Math.min(CONFIG.ROAD_HALF_WIDTH, _getWorldX(touches[0].x)));
+        return false;
     }
-    return false;
+    return true;
 }
 
 function touchStarted() {
     if (game && game.state === 'playing' && touches.length > 0) {
         game.inputX = Math.max(-CONFIG.ROAD_HALF_WIDTH, Math.min(CONFIG.ROAD_HALF_WIDTH, _getWorldX(touches[0].x)));
+        return false;
     }
-    return false;
+    return true;
 }

--- a/docs/js/leaderboard.js
+++ b/docs/js/leaderboard.js
@@ -19,7 +19,9 @@ function getLbPlayer() {
     try { const r = localStorage.getItem(LB_STORAGE_KEY); return r ? JSON.parse(r) : null; } catch { return null; }
 }
 function _saveLbPlayer(name, recordId, hidden) {
-    localStorage.setItem(LB_STORAGE_KEY, JSON.stringify({ name, recordId, hidden: !!hidden }));
+    try {
+        localStorage.setItem(LB_STORAGE_KEY, JSON.stringify({ name, recordId, hidden: !!hidden }));
+    } catch (_) {}
 }
 
 function _sanitizeLbName(name) {

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -496,9 +496,9 @@ function getHighScore() {
 }
 
 (function migrateHighScore() {
-    const raw = localStorage.getItem('bridgeAssault_highScore');
-    if (!raw) return;
     try {
+        const raw = localStorage.getItem('bridgeAssault_highScore');
+        if (!raw) return;
         const parsed = JSON.parse(raw);
         if (parsed && parsed.score !== undefined && parsed.d === undefined) {
             _signedSave('bridgeAssault_highScore', parsed);


### PR DESCRIPTION
## Summary
- guard localStorage reads/writes used during boot, language selection, leaderboard persistence, and legacy high-score migration
- allow touch events to reach menus/overlays when gameplay is not actively running
- bump asset/script cache versions so deployed pages pick up the fixes

## Commit policy
This branch intentionally uses small commits, each tied to one effective fix. Use a merge commit or rebase merge if you want to preserve the commit history; avoid squash merge.

## Verification
- for f in docs/js/*.js; do node --check "" || exit 1; done
- git diff --check origin/main..HEAD
- loaded http://127.0.0.1:8000/
- confirmed all JS scripts use ?v=42 and stylesheet uses ?v=23
- toggled language, started Level 1, verified paused touch handler returns true
- checked browser console for errors under HTTP