### PR TITLE
Cap achievement toast queue at 4 to stop multi-unlock pile-ups, Closes #174

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=41"></script>
-<script src="js/config.js?v=41"></script>
-<script src="js/i18n.js?v=41"></script>
-<script src="js/globals.js?v=41"></script>
-<script src="js/audio.js?v=41"></script>
-<script src="js/core.js?v=41"></script>
-<script src="js/helpers.js?v=41"></script>
-<script src="js/spawn.js?v=41"></script>
-<script src="js/combat.js?v=41"></script>
-<script src="js/draw.js?v=41"></script>
-<script src="js/hud.js?v=41"></script>
-<script src="js/update_timers.js?v=41"></script>
-<script src="js/update_collision.js?v=41"></script>
-<script src="js/update_enemies.js?v=41"></script>
-<script src="js/update_world.js?v=41"></script>
-<script src="js/update_effects.js?v=41"></script>
-<script src="js/update.js?v=41"></script>
-<script src="js/render.js?v=41"></script>
-<script src="js/achievements.js?v=41"></script>
-<script src="js/shop.js?v=41"></script>
-<script src="js/leaderboard.js?v=41"></script>
-<script src="js/input.js?v=41"></script>
-<script src="js/ui.js?v=41"></script>
-<script src="js/tutorial.js?v=41"></script>
-<script src="js/main.js?v=41"></script>
+<script src="js/crypto.js?v=42"></script>
+<script src="js/config.js?v=42"></script>
+<script src="js/i18n.js?v=42"></script>
+<script src="js/globals.js?v=42"></script>
+<script src="js/audio.js?v=42"></script>
+<script src="js/core.js?v=42"></script>
+<script src="js/helpers.js?v=42"></script>
+<script src="js/spawn.js?v=42"></script>
+<script src="js/combat.js?v=42"></script>
+<script src="js/draw.js?v=42"></script>
+<script src="js/hud.js?v=42"></script>
+<script src="js/update_timers.js?v=42"></script>
+<script src="js/update_collision.js?v=42"></script>
+<script src="js/update_enemies.js?v=42"></script>
+<script src="js/update_world.js?v=42"></script>
+<script src="js/update_effects.js?v=42"></script>
+<script src="js/update.js?v=42"></script>
+<script src="js/render.js?v=42"></script>
+<script src="js/achievements.js?v=42"></script>
+<script src="js/shop.js?v=42"></script>
+<script src="js/leaderboard.js?v=42"></script>
+<script src="js/input.js?v=42"></script>
+<script src="js/ui.js?v=42"></script>
+<script src="js/tutorial.js?v=42"></script>
+<script src="js/main.js?v=42"></script>
 </body>
 </html>

--- a/docs/js/achievements.js
+++ b/docs/js/achievements.js
@@ -278,9 +278,16 @@ function resetAchTempFlags() {
 let _achToastQueue = [];
 let _achCurrentToast = null;
 
+// Each toast displays for ~3s; capping the backlog prevents a burst of
+// simultaneous unlocks (e.g. first kill after a long absence) from
+// monopolising the HUD with 30+ seconds of queued notifications. Surplus
+// achievements still unlock in playerData — only the popup is skipped.
+const ACH_TOAST_QUEUE_MAX = 4;
+
 function _queueAchToast(achId, tier) {
     const def = ACHIEVEMENTS[achId];
     if (!def) return;
+    if (_achToastQueue.length >= ACH_TOAST_QUEUE_MAX) return;
     const reward = def.rewards[tier - 1];
     const rewardText = reward.coins ? `+${reward.coins} coins` : `+${reward.gems} gems`;
     _achToastQueue.push({ id: achId, name: def.name, tier, desc: def.desc[tier - 1], reward: rewardText });

--- a/docs/js/globals.js
+++ b/docs/js/globals.js
@@ -61,17 +61,20 @@ const MAIN_MENU_TEMPLATE = overlay ? overlay.innerHTML : '';
 
 const DATA_VERSION = 'v2';
 (function checkDataVersion() {
-    const stored = localStorage.getItem('bridgeAssault_dataVersion');
+    let stored = null;
+    try { stored = localStorage.getItem('bridgeAssault_dataVersion'); } catch (_) { return; }
     if (stored !== DATA_VERSION) {
-        localStorage.setItem('bridgeAssault_dataVersion', DATA_VERSION);
+        try { localStorage.setItem('bridgeAssault_dataVersion', DATA_VERSION); } catch (_) {}
     }
 })();
 
 function resetBridgeAssaultSaveData() {
-    Object.keys(localStorage)
-        .filter(k => k.startsWith('bridgeAssault_'))
-        .forEach(k => localStorage.removeItem(k));
-    localStorage.setItem('bridgeAssault_dataVersion', DATA_VERSION);
+    try {
+        Object.keys(localStorage)
+            .filter(k => k.startsWith('bridgeAssault_'))
+            .forEach(k => localStorage.removeItem(k));
+        localStorage.setItem('bridgeAssault_dataVersion', DATA_VERSION);
+    } catch (_) {}
 }
 
 function loadPlayerData() {

--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -1,7 +1,15 @@
 // ============================================================
 // INTERNATIONALIZATION (i18n)
 // ============================================================
-let LANG = localStorage.getItem('bridgeAssault_lang') || 'en';
+function _safeGetLocalStorage(key) {
+    try { return localStorage.getItem(key); } catch (_) { return null; }
+}
+
+function _safeSetLocalStorage(key, value) {
+    try { localStorage.setItem(key, value); return true; } catch (_) { return false; }
+}
+
+let LANG = _safeGetLocalStorage('bridgeAssault_lang') || 'en';
 
 // T(key, ...args) — look up translation, replace {0} {1} placeholders
 function T(key) {
@@ -14,7 +22,7 @@ function T(key) {
 
 function setLang(lang) {
     LANG = lang;
-    localStorage.setItem('bridgeAssault_lang', lang);
+    _safeSetLocalStorage('bridgeAssault_lang', lang);
     // Update html lang attribute
     document.documentElement.lang = lang;
     applyLang();

--- a/docs/js/leaderboard.js
+++ b/docs/js/leaderboard.js
@@ -19,7 +19,9 @@ function getLbPlayer() {
     try { const r = localStorage.getItem(LB_STORAGE_KEY); return r ? JSON.parse(r) : null; } catch { return null; }
 }
 function _saveLbPlayer(name, recordId, hidden) {
-    localStorage.setItem(LB_STORAGE_KEY, JSON.stringify({ name, recordId, hidden: !!hidden }));
+    try {
+        localStorage.setItem(LB_STORAGE_KEY, JSON.stringify({ name, recordId, hidden: !!hidden }));
+    } catch (_) {}
 }
 
 function _sanitizeLbName(name) {


### PR DESCRIPTION
## Summary
`_queueAchToast` pushed unconditionally; each toast takes ~3 s to drain. `checkAchievements` runs on every kill / pickup / wave end and can unlock several tiers in one sweep — returning with a backlog of unclaimed stats can queue 8-10+ toasts at once, monopolising the HUD bottom-center for 30 + s.

This PR adds an `ACH_TOAST_QUEUE_MAX = 4` cap. Surplus toasts past the cap are dropped. Achievements still unlock in `playerData.achievements` regardless — only the in-game popup is skipped, and players can browse the full set in the achievements panel.

Cache-buster bumped `?v=41 → v=42`.

## Test plan
- [ ] Normal play: unlocking 1-3 achievements at a time still shows each toast.
- [ ] Backlog scenario: contrive 6+ unlocks in a single `checkAchievements` sweep (e.g., via the cheat panel manually nudging stats), see only 4 toasts queue. Remaining ones still appear in the achievements panel as unlocked.

Closes #174