### PR TITLE
Tick explosion timer with dtF for fps-stable duration, Closes #176

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=42"></script>
-<script src="js/config.js?v=42"></script>
-<script src="js/i18n.js?v=42"></script>
-<script src="js/globals.js?v=42"></script>
-<script src="js/audio.js?v=42"></script>
-<script src="js/core.js?v=42"></script>
-<script src="js/helpers.js?v=42"></script>
-<script src="js/spawn.js?v=42"></script>
-<script src="js/combat.js?v=42"></script>
-<script src="js/draw.js?v=42"></script>
-<script src="js/hud.js?v=42"></script>
-<script src="js/update_timers.js?v=42"></script>
-<script src="js/update_collision.js?v=42"></script>
-<script src="js/update_enemies.js?v=42"></script>
-<script src="js/update_world.js?v=42"></script>
-<script src="js/update_effects.js?v=42"></script>
-<script src="js/update.js?v=42"></script>
-<script src="js/render.js?v=42"></script>
-<script src="js/achievements.js?v=42"></script>
-<script src="js/shop.js?v=42"></script>
-<script src="js/leaderboard.js?v=42"></script>
-<script src="js/input.js?v=42"></script>
-<script src="js/ui.js?v=42"></script>
-<script src="js/tutorial.js?v=42"></script>
-<script src="js/main.js?v=42"></script>
+<script src="js/crypto.js?v=43"></script>
+<script src="js/config.js?v=43"></script>
+<script src="js/i18n.js?v=43"></script>
+<script src="js/globals.js?v=43"></script>
+<script src="js/audio.js?v=43"></script>
+<script src="js/core.js?v=43"></script>
+<script src="js/helpers.js?v=43"></script>
+<script src="js/spawn.js?v=43"></script>
+<script src="js/combat.js?v=43"></script>
+<script src="js/draw.js?v=43"></script>
+<script src="js/hud.js?v=43"></script>
+<script src="js/update_timers.js?v=43"></script>
+<script src="js/update_collision.js?v=43"></script>
+<script src="js/update_enemies.js?v=43"></script>
+<script src="js/update_world.js?v=43"></script>
+<script src="js/update_effects.js?v=43"></script>
+<script src="js/update.js?v=43"></script>
+<script src="js/render.js?v=43"></script>
+<script src="js/achievements.js?v=43"></script>
+<script src="js/shop.js?v=43"></script>
+<script src="js/leaderboard.js?v=43"></script>
+<script src="js/input.js?v=43"></script>
+<script src="js/ui.js?v=43"></script>
+<script src="js/tutorial.js?v=43"></script>
+<script src="js/main.js?v=43"></script>
 </body>
 </html>

--- a/docs/js/update_effects.js
+++ b/docs/js/update_effects.js
@@ -29,8 +29,9 @@ function updateEffects(g, dt, dtF) {
     const particleLimit = _proj.isMobile ? 120 : (frameMs > 30 ? 150 : frameMs > 22 ? 250 : 400);
     if (g.particles.length > particleLimit) g.particles.splice(0, g.particles.length - Math.floor(particleLimit * 0.75));
 
-    // Explosions
-    g.explosions.forEach(e => e.timer++);
+    // Explosions — use dtF so duration stays wall-clock-stable when the
+    // frame rate dips (every other timer in this file already uses dtF).
+    g.explosions.forEach(e => e.timer += dtF);
     g.explosions = g.explosions.filter(e => e.timer < e.maxTimer);
     if (g.explosions.length > 40) g.explosions.splice(0, g.explosions.length - 30);
 


### PR DESCRIPTION
## Summary
`g.explosions` used `e.timer++` (per-frame increment) while every other ephemeral array in `update_effects.js` ticks with `dtF` (frame-scaled). `maxTimer` values in `combat.js` (20/30/48/75 frames) were calibrated at 60 fps — at 30 fps each explosion visually stretched to ~2× the intended duration, making barrel chains and boss-death cascades drag on slower devices.

## Fix
`e.timer += dtF` in `update_effects.js:33`. `maxTimer` values are unchanged; behaviour at 60 fps is identical.

Cache-buster bumped `?v=42 → v=43`.

## Test plan
- [ ] Normal play at 60 fps: barrel-chain blast rings look identical to before.
- [ ] DevTools → Performance → CPU 6× slowdown: explosion duration is now visually consistent with 60-fps reference (no more stretched 1+ s rings).

Closes #176