### PR TITLE
Use Math.max for shield-deflect shake floor, Closes #179

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=43"></script>
-<script src="js/config.js?v=43"></script>
-<script src="js/i18n.js?v=43"></script>
-<script src="js/globals.js?v=43"></script>
-<script src="js/audio.js?v=43"></script>
-<script src="js/core.js?v=43"></script>
-<script src="js/helpers.js?v=43"></script>
-<script src="js/spawn.js?v=43"></script>
-<script src="js/combat.js?v=43"></script>
-<script src="js/draw.js?v=43"></script>
-<script src="js/hud.js?v=43"></script>
-<script src="js/update_timers.js?v=43"></script>
-<script src="js/update_collision.js?v=43"></script>
-<script src="js/update_enemies.js?v=43"></script>
-<script src="js/update_world.js?v=43"></script>
-<script src="js/update_effects.js?v=43"></script>
-<script src="js/update.js?v=43"></script>
-<script src="js/render.js?v=43"></script>
-<script src="js/achievements.js?v=43"></script>
-<script src="js/shop.js?v=43"></script>
-<script src="js/leaderboard.js?v=43"></script>
-<script src="js/input.js?v=43"></script>
-<script src="js/ui.js?v=43"></script>
-<script src="js/tutorial.js?v=43"></script>
-<script src="js/main.js?v=43"></script>
+<script src="js/crypto.js?v=44"></script>
+<script src="js/config.js?v=44"></script>
+<script src="js/i18n.js?v=44"></script>
+<script src="js/globals.js?v=44"></script>
+<script src="js/audio.js?v=44"></script>
+<script src="js/core.js?v=44"></script>
+<script src="js/helpers.js?v=44"></script>
+<script src="js/spawn.js?v=44"></script>
+<script src="js/combat.js?v=44"></script>
+<script src="js/draw.js?v=44"></script>
+<script src="js/hud.js?v=44"></script>
+<script src="js/update_timers.js?v=44"></script>
+<script src="js/update_collision.js?v=44"></script>
+<script src="js/update_enemies.js?v=44"></script>
+<script src="js/update_world.js?v=44"></script>
+<script src="js/update_effects.js?v=44"></script>
+<script src="js/update.js?v=44"></script>
+<script src="js/render.js?v=44"></script>
+<script src="js/achievements.js?v=44"></script>
+<script src="js/shop.js?v=44"></script>
+<script src="js/leaderboard.js?v=44"></script>
+<script src="js/input.js?v=44"></script>
+<script src="js/ui.js?v=44"></script>
+<script src="js/tutorial.js?v=44"></script>
+<script src="js/main.js?v=44"></script>
 </body>
 </html>

--- a/docs/js/update_enemies.js
+++ b/docs/js/update_enemies.js
@@ -387,7 +387,10 @@ function updateEnemies(g, dt, dtF, bossAlive) {
                 if (g.shieldActive) {
                     // invincible: deflect effect, no troop loss
                     addParticles(g.player.x, pz, 10, 0xffdd44, 3, 12);
-                    g.shakeTimer = Math.min(g.shakeTimer, 3);
+                    // Floor at 3 frames so a deflect always feels confirmed —
+                    // Math.min was a typo and produced 0 shake when the timer
+                    // was at 0 (the common case).
+                    g.shakeTimer = Math.max(g.shakeTimer, 3);
                 } else {
                 // Dodge (Miss) chance: base 7.5%, +0.25% per player level above 1, no hard cap
                 // Lucky Break talent applies as a multiplier; level + luck together determine final chance


### PR DESCRIPTION
## Summary
`update_enemies.js:390` had `Math.min(g.shakeTimer, 3)` on the shield-deflect path. The intent — "ensure at least 3 frames of shake on a deflect" — actually requires `Math.max`. With `Math.min`, when `shakeTimer` is 0 (the common steady state) the result is 0 and the deflect produces no shake at all; when an ongoing shake is in progress the deflect would actually **lower** it.

Every other "ensure ≥ N" usage of `shakeTimer` in the codebase uses `Math.max` (`combat.js:269`, `update_world.js:83`, etc.). This is just a typo on a single line.

## Fix
```js
g.shakeTimer = Math.max(g.shakeTimer, 3);
```

Cache-buster bumped `?v=43 → v=44`.

## Test plan
- [ ] Activate Shield (key 1) → walk into a boss bullet → screen shakes briefly. Without shield active, behavior unchanged.
- [ ] Multiple shielded hits in a row don't compound past their natural cap.

Closes #179