### PR TITLE
Decrement gate fadeTimer by dtF instead of per frame, Closes #181

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=44"></script>
-<script src="js/config.js?v=44"></script>
-<script src="js/i18n.js?v=44"></script>
-<script src="js/globals.js?v=44"></script>
-<script src="js/audio.js?v=44"></script>
-<script src="js/core.js?v=44"></script>
-<script src="js/helpers.js?v=44"></script>
-<script src="js/spawn.js?v=44"></script>
-<script src="js/combat.js?v=44"></script>
-<script src="js/draw.js?v=44"></script>
-<script src="js/hud.js?v=44"></script>
-<script src="js/update_timers.js?v=44"></script>
-<script src="js/update_collision.js?v=44"></script>
-<script src="js/update_enemies.js?v=44"></script>
-<script src="js/update_world.js?v=44"></script>
-<script src="js/update_effects.js?v=44"></script>
-<script src="js/update.js?v=44"></script>
-<script src="js/render.js?v=44"></script>
-<script src="js/achievements.js?v=44"></script>
-<script src="js/shop.js?v=44"></script>
-<script src="js/leaderboard.js?v=44"></script>
-<script src="js/input.js?v=44"></script>
-<script src="js/ui.js?v=44"></script>
-<script src="js/tutorial.js?v=44"></script>
-<script src="js/main.js?v=44"></script>
+<script src="js/crypto.js?v=45"></script>
+<script src="js/config.js?v=45"></script>
+<script src="js/i18n.js?v=45"></script>
+<script src="js/globals.js?v=45"></script>
+<script src="js/audio.js?v=45"></script>
+<script src="js/core.js?v=45"></script>
+<script src="js/helpers.js?v=45"></script>
+<script src="js/spawn.js?v=45"></script>
+<script src="js/combat.js?v=45"></script>
+<script src="js/draw.js?v=45"></script>
+<script src="js/hud.js?v=45"></script>
+<script src="js/update_timers.js?v=45"></script>
+<script src="js/update_collision.js?v=45"></script>
+<script src="js/update_enemies.js?v=45"></script>
+<script src="js/update_world.js?v=45"></script>
+<script src="js/update_effects.js?v=45"></script>
+<script src="js/update.js?v=45"></script>
+<script src="js/render.js?v=45"></script>
+<script src="js/achievements.js?v=45"></script>
+<script src="js/shop.js?v=45"></script>
+<script src="js/leaderboard.js?v=45"></script>
+<script src="js/input.js?v=45"></script>
+<script src="js/ui.js?v=45"></script>
+<script src="js/tutorial.js?v=45"></script>
+<script src="js/main.js?v=45"></script>
 </body>
 </html>

--- a/docs/js/update_world.js
+++ b/docs/js/update_world.js
@@ -4,7 +4,12 @@
 function updateWorld(g, dt, dtF, bossAlive) {
     // Gate collision
     g.gates.forEach(gate => {
-        if (gate.triggered && gate.fadeTimer > 0) { gate.fadeTimer--; return; }
+        if (gate.triggered && gate.fadeTimer > 0) {
+            // Use dtF so the fade duration stays wall-clock-stable when the
+            // frame rate dips (matches the rest of the effect timers).
+            gate.fadeTimer = Math.max(0, gate.fadeTimer - dtF);
+            return;
+        }
         if (gate.triggered) return;
         const relZ = gate.z - g.cameraZ;
         if (relZ <= 8 && relZ > -25) {


### PR DESCRIPTION
## Summary
`update_world.js:7` decremented `gate.fadeTimer` by 1 per frame, while every other ephemeral effect timer in the codebase uses `dtF` (frame-scaled). `fadeTimer` is set to 60 on trigger; the resulting fade lasts ~1 s at 60 fps but ~2 s at 30 fps. Same fps-dependent stretch the explosion timer had before #177.

`draw.js:652` reads progress as `1 - gate.fadeTimer / 60`, which is a ratio — unaffected by switching the increment unit.

## Fix
`gate.fadeTimer = Math.max(0, gate.fadeTimer - dtF);`. The `Math.max` floor at 0 keeps the post-fade filter in `update_effects.js:18` cleanly dropping the gate. `fadeTimer = 60` initial value stays.

Cache-buster bumped `?v=44 → v=45`.

## Test plan
- [ ] Walk through any +/- gate at 60 fps: fade-out timing visually unchanged from before.
- [ ] DevTools → Performance → CPU 6× slowdown → walk through a gate: fade lasts the same wall-clock duration as 60 fps (~1 s), no longer drags to 2 s.

Closes #181