### PR TITLE
Tick achievement toast timer with dtF for fps-stable duration, Closes #183

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=45"></script>
-<script src="js/config.js?v=45"></script>
-<script src="js/i18n.js?v=45"></script>
-<script src="js/globals.js?v=45"></script>
-<script src="js/audio.js?v=45"></script>
-<script src="js/core.js?v=45"></script>
-<script src="js/helpers.js?v=45"></script>
-<script src="js/spawn.js?v=45"></script>
-<script src="js/combat.js?v=45"></script>
-<script src="js/draw.js?v=45"></script>
-<script src="js/hud.js?v=45"></script>
-<script src="js/update_timers.js?v=45"></script>
-<script src="js/update_collision.js?v=45"></script>
-<script src="js/update_enemies.js?v=45"></script>
-<script src="js/update_world.js?v=45"></script>
-<script src="js/update_effects.js?v=45"></script>
-<script src="js/update.js?v=45"></script>
-<script src="js/render.js?v=45"></script>
-<script src="js/achievements.js?v=45"></script>
-<script src="js/shop.js?v=45"></script>
-<script src="js/leaderboard.js?v=45"></script>
-<script src="js/input.js?v=45"></script>
-<script src="js/ui.js?v=45"></script>
-<script src="js/tutorial.js?v=45"></script>
-<script src="js/main.js?v=45"></script>
+<script src="js/crypto.js?v=46"></script>
+<script src="js/config.js?v=46"></script>
+<script src="js/i18n.js?v=46"></script>
+<script src="js/globals.js?v=46"></script>
+<script src="js/audio.js?v=46"></script>
+<script src="js/core.js?v=46"></script>
+<script src="js/helpers.js?v=46"></script>
+<script src="js/spawn.js?v=46"></script>
+<script src="js/combat.js?v=46"></script>
+<script src="js/draw.js?v=46"></script>
+<script src="js/hud.js?v=46"></script>
+<script src="js/update_timers.js?v=46"></script>
+<script src="js/update_collision.js?v=46"></script>
+<script src="js/update_enemies.js?v=46"></script>
+<script src="js/update_world.js?v=46"></script>
+<script src="js/update_effects.js?v=46"></script>
+<script src="js/update.js?v=46"></script>
+<script src="js/render.js?v=46"></script>
+<script src="js/achievements.js?v=46"></script>
+<script src="js/shop.js?v=46"></script>
+<script src="js/leaderboard.js?v=46"></script>
+<script src="js/input.js?v=46"></script>
+<script src="js/ui.js?v=46"></script>
+<script src="js/tutorial.js?v=46"></script>
+<script src="js/main.js?v=46"></script>
 </body>
 </html>

--- a/docs/js/achievements.js
+++ b/docs/js/achievements.js
@@ -394,7 +394,10 @@ function drawAchievementToast() {
     if (!_achCurrentToast) return;
 
     const toast = _achCurrentToast;
-    toast.timer++;
+    // Tick by dtF (matches update.js) so the toast keeps a stable ~3s
+    // wall-clock duration when the frame rate dips. Per-frame increment
+    // doubled the visible time at 30fps.
+    toast.timer += Math.min(typeof deltaTime === 'number' ? deltaTime : 16.667, 50) / 16.667;
     if (toast.timer >= toast.maxTimer) {
         _achCurrentToast = null;
         return;


### PR DESCRIPTION
## Summary
`drawAchievementToast` incremented `toast.timer` by 1 per render call. `maxTimer = 180` — at 60 fps that's ~3 s wall-clock, but at 30 fps it stretches to ~6 s. Same fps-dependent stretch as the gate fade (fixed in #182) and explosion timer (#177).

## Fix
Read p5's per-frame `deltaTime` and increment by the same `Math.min(deltaTime, 50) / 16.667` formula `update.js` uses. Behaviour at 60 fps unchanged; at 30 fps a toast now drains in ~3 s instead of ~6 s.

Cache-buster bumped `?v=45 → v=46`.

## Test plan
- [ ] Trigger an achievement (e.g., 100 kills) at 60 fps: toast still visible for ~3 s.
- [ ] DevTools → Performance → CPU 6× slowdown → trigger achievement: toast drains in roughly the same wall-clock duration as 60 fps reference.

Closes #183