### PR TITLE
Make damaged-barrel smoke emission rate fps-stable, Closes #186

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=46"></script>
-<script src="js/config.js?v=46"></script>
-<script src="js/i18n.js?v=46"></script>
-<script src="js/globals.js?v=46"></script>
-<script src="js/audio.js?v=46"></script>
-<script src="js/core.js?v=46"></script>
-<script src="js/helpers.js?v=46"></script>
-<script src="js/spawn.js?v=46"></script>
-<script src="js/combat.js?v=46"></script>
-<script src="js/draw.js?v=46"></script>
-<script src="js/hud.js?v=46"></script>
-<script src="js/update_timers.js?v=46"></script>
-<script src="js/update_collision.js?v=46"></script>
-<script src="js/update_enemies.js?v=46"></script>
-<script src="js/update_world.js?v=46"></script>
-<script src="js/update_effects.js?v=46"></script>
-<script src="js/update.js?v=46"></script>
-<script src="js/render.js?v=46"></script>
-<script src="js/achievements.js?v=46"></script>
-<script src="js/shop.js?v=46"></script>
-<script src="js/leaderboard.js?v=46"></script>
-<script src="js/input.js?v=46"></script>
-<script src="js/ui.js?v=46"></script>
-<script src="js/tutorial.js?v=46"></script>
-<script src="js/main.js?v=46"></script>
+<script src="js/crypto.js?v=47"></script>
+<script src="js/config.js?v=47"></script>
+<script src="js/i18n.js?v=47"></script>
+<script src="js/globals.js?v=47"></script>
+<script src="js/audio.js?v=47"></script>
+<script src="js/core.js?v=47"></script>
+<script src="js/helpers.js?v=47"></script>
+<script src="js/spawn.js?v=47"></script>
+<script src="js/combat.js?v=47"></script>
+<script src="js/draw.js?v=47"></script>
+<script src="js/hud.js?v=47"></script>
+<script src="js/update_timers.js?v=47"></script>
+<script src="js/update_collision.js?v=47"></script>
+<script src="js/update_enemies.js?v=47"></script>
+<script src="js/update_world.js?v=47"></script>
+<script src="js/update_effects.js?v=47"></script>
+<script src="js/update.js?v=47"></script>
+<script src="js/render.js?v=47"></script>
+<script src="js/achievements.js?v=47"></script>
+<script src="js/shop.js?v=47"></script>
+<script src="js/leaderboard.js?v=47"></script>
+<script src="js/input.js?v=47"></script>
+<script src="js/ui.js?v=47"></script>
+<script src="js/tutorial.js?v=47"></script>
+<script src="js/main.js?v=47"></script>
 </body>
 </html>

--- a/docs/js/update_world.js
+++ b/docs/js/update_world.js
@@ -148,11 +148,13 @@ function updateWorld(g, dt, dtF, bossAlive) {
         else if (br.chainTimer === 0) { br.chainTimer = -1; explodeBarrel(br); }
     });
 
-    // Barrel smoke/sparks for damaged barrels
+    // Barrel smoke/sparks for damaged barrels — probabilistic emission keyed
+    // off dtF so the per-second rate stays constant across frame rates
+    // (per-frame modulo halved the smoke at 30fps).
     g.barrels.forEach(br => {
         if (!br.alive || br.hp >= br.maxHp) return;
-        br.smokeTimer++;
-        if (br.smokeTimer % 6 === 0) {
+        br.smokeTimer += dtF;
+        if (Math.random() < dtF / 6) {
             g.particles.push({
                 x: br.x + (Math.random() - 0.5) * 10, z: br.z,
                 vx: (Math.random() - 0.5) * 0.5, vz: 0,
@@ -161,7 +163,7 @@ function updateWorld(g, dt, dtF, bossAlive) {
                 color: 0x555555, size: 3 + Math.random() * 3,
             });
         }
-        if (br.smokeTimer % 10 === 0) {
+        if (Math.random() < dtF / 10) {
             g.particles.push({
                 x: br.x + (Math.random() - 0.5) * 8, z: br.z,
                 vx: (Math.random() - 0.5) * 2, vz: (Math.random() - 0.5),


### PR DESCRIPTION
## Summary
`update_world.js:152-172` emitted smoke / sparks for damaged barrels using a per-frame `br.smokeTimer++` + modulo gate. At 30 fps the rate halved — damaged barrels looked visibly less smoky on slower devices.

## Fix
Switch to a probabilistic per-frame emit using `dtF`. Per-second rate stays constant across frame rates:

```js
br.smokeTimer += dtF;
if (Math.random() < dtF / 6)  emit_grey();
if (Math.random() < dtF / 10) emit_orange();
```

At dtF=1 (60fps): 0.167 chance/frame × 60 = 10/sec grey, 0.1 × 60 = 6/sec orange.
At dtF=2 (30fps): 0.333 chance/frame × 30 = 10/sec grey, 0.2 × 30 = 6/sec orange.

Cache-buster bumped `?v=46 → v=47`.

## Test plan
- [ ] Damage a barrel at 60 fps: smoke and orange spark emission visually unchanged from before.
- [ ] DevTools → Performance → CPU 6× slowdown → damage barrel: smoke / spark rate stays the same wall-clock as 60 fps reference.

Closes #186