### PR TITLE
Trigger barrel chain explosion on cross-zero, not on exact 0, Closes #188

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=47"></script>
-<script src="js/config.js?v=47"></script>
-<script src="js/i18n.js?v=47"></script>
-<script src="js/globals.js?v=47"></script>
-<script src="js/audio.js?v=47"></script>
-<script src="js/core.js?v=47"></script>
-<script src="js/helpers.js?v=47"></script>
-<script src="js/spawn.js?v=47"></script>
-<script src="js/combat.js?v=47"></script>
-<script src="js/draw.js?v=47"></script>
-<script src="js/hud.js?v=47"></script>
-<script src="js/update_timers.js?v=47"></script>
-<script src="js/update_collision.js?v=47"></script>
-<script src="js/update_enemies.js?v=47"></script>
-<script src="js/update_world.js?v=47"></script>
-<script src="js/update_effects.js?v=47"></script>
-<script src="js/update.js?v=47"></script>
-<script src="js/render.js?v=47"></script>
-<script src="js/achievements.js?v=47"></script>
-<script src="js/shop.js?v=47"></script>
-<script src="js/leaderboard.js?v=47"></script>
-<script src="js/input.js?v=47"></script>
-<script src="js/ui.js?v=47"></script>
-<script src="js/tutorial.js?v=47"></script>
-<script src="js/main.js?v=47"></script>
+<script src="js/crypto.js?v=48"></script>
+<script src="js/config.js?v=48"></script>
+<script src="js/i18n.js?v=48"></script>
+<script src="js/globals.js?v=48"></script>
+<script src="js/audio.js?v=48"></script>
+<script src="js/core.js?v=48"></script>
+<script src="js/helpers.js?v=48"></script>
+<script src="js/spawn.js?v=48"></script>
+<script src="js/combat.js?v=48"></script>
+<script src="js/draw.js?v=48"></script>
+<script src="js/hud.js?v=48"></script>
+<script src="js/update_timers.js?v=48"></script>
+<script src="js/update_collision.js?v=48"></script>
+<script src="js/update_enemies.js?v=48"></script>
+<script src="js/update_world.js?v=48"></script>
+<script src="js/update_effects.js?v=48"></script>
+<script src="js/update.js?v=48"></script>
+<script src="js/render.js?v=48"></script>
+<script src="js/achievements.js?v=48"></script>
+<script src="js/shop.js?v=48"></script>
+<script src="js/leaderboard.js?v=48"></script>
+<script src="js/input.js?v=48"></script>
+<script src="js/ui.js?v=48"></script>
+<script src="js/tutorial.js?v=48"></script>
+<script src="js/main.js?v=48"></script>
 </body>
 </html>

--- a/docs/js/update_world.js
+++ b/docs/js/update_world.js
@@ -141,11 +141,17 @@ function updateWorld(g, dt, dtF, bossAlive) {
     }
     if (g.cameraZ + CONFIG.SPAWN_DISTANCE > g.nextGateZ) spawnGate();
 
-    // Barrel chain reaction timers
+    // Barrel chain reaction timers — fire when the timer reaches 0 or
+    // crosses below it. The previous `=== 0` branch could be skipped
+    // entirely when dtF was not a whole number (50fps -> 1.2, 75fps -> 0.8),
+    // because the float decrement jumped from positive to negative without
+    // hitting 0 exactly, leaving the chain barrel inert.
     g.barrels.forEach(br => {
         if (!br.alive || br.chainTimer < 0) return;
-        if (br.chainTimer > 0) { br.chainTimer -= dtF; }
-        else if (br.chainTimer === 0) { br.chainTimer = -1; explodeBarrel(br); }
+        if (br.chainTimer > 0) {
+            br.chainTimer -= dtF;
+            if (br.chainTimer <= 0) { br.chainTimer = -1; explodeBarrel(br); }
+        }
     });
 
     // Barrel smoke/sparks for damaged barrels — probabilistic emission keyed


### PR DESCRIPTION
## Summary
`update_world.js:148` fired `explodeBarrel(br)` only when `br.chainTimer === 0`, but `chainTimer` is decremented by `dtF` which is a float at any frame rate other than 60fps (50fps → 1.2, 75fps → 0.8, throttled tab → smaller values). Starting from `chainTimer = 8`, non-integer `dtF` skips 0 entirely and the chain barrel never explodes.

Trace at 50fps:
```
8.0 → 6.8 → 5.6 → 4.4 → 3.2 → 2.0 → 0.8 → -0.4 ← never landed on 0
```
Once negative, the early-return at line 146 fires forever and the barrel sits inert despite an obvious hit on its neighbour.

## Fix
Drop the `else if (=== 0)` branch. Inside the `> 0` branch, fire the explosion the moment the timer crosses zero in the same step:

```js
if (br.chainTimer > 0) {
    br.chainTimer -= dtF;
    if (br.chainTimer <= 0) { br.chainTimer = -1; explodeBarrel(br); }
}
```

Same wall-clock delay at 60fps. Correct behaviour at any frame rate.

Cache-buster bumped `?v=47 → v=48`.

## Test plan
- [ ] Place a rocket near a cluster of barrels at 60fps: chain detonation works as before.
- [ ] DevTools Performance throttle to 50fps (or 75fps) → same chain test: every linked barrel still explodes (used to leave some inert).

Closes #188