### PR TITLE
Floor ground-slam vignetteFlash with Math.max instead of constant 0.9, Closes #192

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=48"></script>
-<script src="js/config.js?v=48"></script>
-<script src="js/i18n.js?v=48"></script>
-<script src="js/globals.js?v=48"></script>
-<script src="js/audio.js?v=48"></script>
-<script src="js/core.js?v=48"></script>
-<script src="js/helpers.js?v=48"></script>
-<script src="js/spawn.js?v=48"></script>
-<script src="js/combat.js?v=48"></script>
-<script src="js/draw.js?v=48"></script>
-<script src="js/hud.js?v=48"></script>
-<script src="js/update_timers.js?v=48"></script>
-<script src="js/update_collision.js?v=48"></script>
-<script src="js/update_enemies.js?v=48"></script>
-<script src="js/update_world.js?v=48"></script>
-<script src="js/update_effects.js?v=48"></script>
-<script src="js/update.js?v=48"></script>
-<script src="js/render.js?v=48"></script>
-<script src="js/achievements.js?v=48"></script>
-<script src="js/shop.js?v=48"></script>
-<script src="js/leaderboard.js?v=48"></script>
-<script src="js/input.js?v=48"></script>
-<script src="js/ui.js?v=48"></script>
-<script src="js/tutorial.js?v=48"></script>
-<script src="js/main.js?v=48"></script>
+<script src="js/crypto.js?v=49"></script>
+<script src="js/config.js?v=49"></script>
+<script src="js/i18n.js?v=49"></script>
+<script src="js/globals.js?v=49"></script>
+<script src="js/audio.js?v=49"></script>
+<script src="js/core.js?v=49"></script>
+<script src="js/helpers.js?v=49"></script>
+<script src="js/spawn.js?v=49"></script>
+<script src="js/combat.js?v=49"></script>
+<script src="js/draw.js?v=49"></script>
+<script src="js/hud.js?v=49"></script>
+<script src="js/update_timers.js?v=49"></script>
+<script src="js/update_collision.js?v=49"></script>
+<script src="js/update_enemies.js?v=49"></script>
+<script src="js/update_world.js?v=49"></script>
+<script src="js/update_effects.js?v=49"></script>
+<script src="js/update.js?v=49"></script>
+<script src="js/render.js?v=49"></script>
+<script src="js/achievements.js?v=49"></script>
+<script src="js/shop.js?v=49"></script>
+<script src="js/leaderboard.js?v=49"></script>
+<script src="js/input.js?v=49"></script>
+<script src="js/ui.js?v=49"></script>
+<script src="js/tutorial.js?v=49"></script>
+<script src="js/main.js?v=49"></script>
 </body>
 </html>

--- a/docs/js/update_effects.js
+++ b/docs/js/update_effects.js
@@ -144,7 +144,9 @@ function updateEffects(g, dt, dtF) {
                 const finalDmg = applyTroopDamage(g, sw.damage);
                 g.gateText = { text: `⚡ GROUND SLAM \u2212${finalDmg}!`, color: 0xff2222, timer: 0, maxTimer: 80, scale: 0.1 };
                 g.gateFlash = { color: 0xff2222, timer: 18, maxTimer: 18 };
-                g.vignetteFlash = Math.min(1.5, 0.9);
+                // Floor at 0.9 (capped at 1.5) so a slam doesn't lower an
+                // already-bright vignette from a recent regular hit.
+                g.vignetteFlash = Math.min(1.5, Math.max(g.vignetteFlash, 0.9));
                 addParticles(g.player.x, g.cameraZ + 10, 12, 0xff6644, 4, 15);
                 if (g.squadCount <= 0) { handlePlayerDeath(); }
             } else if (playerInZone && g.shieldActive) {


### PR DESCRIPTION
## Summary
`update_effects.js:147` had `g.vignetteFlash = Math.min(1.5, 0.9)` — that expression is just `0.9`, the cap is dead code. More importantly, an unconditional assignment **lowers** any already-bright vignette (e.g. from a regular hit a few frames earlier), making big slams visually weaker than smaller hits.

`helpers.js emitTroopLossEffects` already shows the codebase pattern: `Math.min(1.5, base + dmg * scale)`.

## Fix
`g.vignetteFlash = Math.min(1.5, Math.max(g.vignetteFlash, 0.9));`
- steady state: 0.9 (same as before)
- already at 1.2: stays 1.2 (slam doesn't undo the prior brighter flash)
- > 1.5: clamped to 1.5

Cache-buster bumped `?v=48 → v=49`.

## Test plan
- [ ] Mega-boss ground slam after a recent regular hit: vignette stays bright, doesn't dim.
- [ ] Slam without prior hits: vignette is 0.9 like before.

Closes #192