### PR TITLE
Floor processEnemyKill shake/flash with Math.max instead of overwriting, Closes #194

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=49"></script>
-<script src="js/config.js?v=49"></script>
-<script src="js/i18n.js?v=49"></script>
-<script src="js/globals.js?v=49"></script>
-<script src="js/audio.js?v=49"></script>
-<script src="js/core.js?v=49"></script>
-<script src="js/helpers.js?v=49"></script>
-<script src="js/spawn.js?v=49"></script>
-<script src="js/combat.js?v=49"></script>
-<script src="js/draw.js?v=49"></script>
-<script src="js/hud.js?v=49"></script>
-<script src="js/update_timers.js?v=49"></script>
-<script src="js/update_collision.js?v=49"></script>
-<script src="js/update_enemies.js?v=49"></script>
-<script src="js/update_world.js?v=49"></script>
-<script src="js/update_effects.js?v=49"></script>
-<script src="js/update.js?v=49"></script>
-<script src="js/render.js?v=49"></script>
-<script src="js/achievements.js?v=49"></script>
-<script src="js/shop.js?v=49"></script>
-<script src="js/leaderboard.js?v=49"></script>
-<script src="js/input.js?v=49"></script>
-<script src="js/ui.js?v=49"></script>
-<script src="js/tutorial.js?v=49"></script>
-<script src="js/main.js?v=49"></script>
+<script src="js/crypto.js?v=50"></script>
+<script src="js/config.js?v=50"></script>
+<script src="js/i18n.js?v=50"></script>
+<script src="js/globals.js?v=50"></script>
+<script src="js/audio.js?v=50"></script>
+<script src="js/core.js?v=50"></script>
+<script src="js/helpers.js?v=50"></script>
+<script src="js/spawn.js?v=50"></script>
+<script src="js/combat.js?v=50"></script>
+<script src="js/draw.js?v=50"></script>
+<script src="js/hud.js?v=50"></script>
+<script src="js/update_timers.js?v=50"></script>
+<script src="js/update_collision.js?v=50"></script>
+<script src="js/update_enemies.js?v=50"></script>
+<script src="js/update_world.js?v=50"></script>
+<script src="js/update_effects.js?v=50"></script>
+<script src="js/update.js?v=50"></script>
+<script src="js/render.js?v=50"></script>
+<script src="js/achievements.js?v=50"></script>
+<script src="js/shop.js?v=50"></script>
+<script src="js/leaderboard.js?v=50"></script>
+<script src="js/input.js?v=50"></script>
+<script src="js/ui.js?v=50"></script>
+<script src="js/tutorial.js?v=50"></script>
+<script src="js/main.js?v=50"></script>
 </body>
 </html>

--- a/docs/js/helpers.js
+++ b/docs/js/helpers.js
@@ -96,7 +96,10 @@ function processEnemyKill(g, enemy, opts) {
         addParticles(enemy.x, enemy.z, 60, 0xff4400, 8, 45);
         addParticles(enemy.x, enemy.z, 30, 0xffaa00, 6, 35);
         addParticles(enemy.x, enemy.z, 20, 0xffffff, 5, 25);
-        g.shakeTimer = 35; g.screenFlash = 0.9;
+        // Floor with Math.max so a subsequent regular kill cant erase
+        // this dramatic shake mid-cascade.
+        g.shakeTimer = Math.max(g.shakeTimer, 35);
+        g.screenFlash = Math.max(g.screenFlash, 0.9);
         g.slowMo = 400;
         const label = enemy.isElephantBoss ? T('boss.elephant') : T('boss.mega');
         addScorePopup(`${label} +${killScore}!`, ep.x, ep.y - 40, 0xff4400);
@@ -109,7 +112,8 @@ function processEnemyKill(g, enemy, opts) {
         addExplosion(enemy.x - 20, enemy.z - 15);
         addParticles(enemy.x, enemy.z, 40, 0xcc66ff, 6, 35);
         addParticles(enemy.x, enemy.z, 20, 0xffffff, 4, 25);
-        g.shakeTimer = 25; g.screenFlash = 0.6;
+        g.shakeTimer = Math.max(g.shakeTimer, 25);
+        g.screenFlash = Math.max(g.screenFlash, 0.6);
         const label = enemy.isCowCryBoss ? T('boss.crycow') : T('boss.dragon');
         const labelColor = enemy.isCowCryBoss ? 0xff9944 : 0xcc66ff;
         addScorePopup(`${label} +${killScore}!`, ep.x, ep.y - 30, labelColor);
@@ -117,7 +121,7 @@ function processEnemyKill(g, enemy, opts) {
         if (enemy.spawnTime && (Date.now() - enemy.spawnTime) < 5000) _achTempFlags.speedKill = true;
         handleBossDeath(g, enemy);
     } else {
-        g.shakeTimer = 5;
+        g.shakeTimer = Math.max(g.shakeTimer, 5);
         addScorePopup(`+${killScore}`, ep.x, ep.y - 20, enemy.isHeavy ? 0xff8800 : 0xffcc00);
         awardKillXP(g, enemy.isHeavy);
         // L2 Pig Hero: splits into 2 minis on death


### PR DESCRIPTION
## Summary
`processEnemyKill` (`helpers.js:99 / 112 / 120`) wrote shake / screenFlash with direct assignment, overwriting any larger ongoing effect. Killing a regular enemy a few frames after a mega-boss death cascade dropped the dramatic 35-frame shake down to 5, cutting the cascade short.

Same pattern as the shield-deflect typo fixed in #180; the codebase's standard "ensure ≥ N" idiom uses `Math.max`.

## Fix
Floor the three sites with `Math.max`. Steady-state (shake/flash are 0 most of the time) is identical to before.

Cache-buster bumped `?v=49 → v=50`.

## Test plan
- [ ] Mega-boss kill, then immediately mow through regular adds: dramatic shake stays full 35 frames instead of being chopped to 5.
- [ ] Normal play with no big shake in progress: kill shake / flash feel unchanged.

Closes #194