### PR TITLE
Floor rocket-AOE shake/flash with Math.max instead of overwriting, Closes #196

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=50"></script>
-<script src="js/config.js?v=50"></script>
-<script src="js/i18n.js?v=50"></script>
-<script src="js/globals.js?v=50"></script>
-<script src="js/audio.js?v=50"></script>
-<script src="js/core.js?v=50"></script>
-<script src="js/helpers.js?v=50"></script>
-<script src="js/spawn.js?v=50"></script>
-<script src="js/combat.js?v=50"></script>
-<script src="js/draw.js?v=50"></script>
-<script src="js/hud.js?v=50"></script>
-<script src="js/update_timers.js?v=50"></script>
-<script src="js/update_collision.js?v=50"></script>
-<script src="js/update_enemies.js?v=50"></script>
-<script src="js/update_world.js?v=50"></script>
-<script src="js/update_effects.js?v=50"></script>
-<script src="js/update.js?v=50"></script>
-<script src="js/render.js?v=50"></script>
-<script src="js/achievements.js?v=50"></script>
-<script src="js/shop.js?v=50"></script>
-<script src="js/leaderboard.js?v=50"></script>
-<script src="js/input.js?v=50"></script>
-<script src="js/ui.js?v=50"></script>
-<script src="js/tutorial.js?v=50"></script>
-<script src="js/main.js?v=50"></script>
+<script src="js/crypto.js?v=51"></script>
+<script src="js/config.js?v=51"></script>
+<script src="js/i18n.js?v=51"></script>
+<script src="js/globals.js?v=51"></script>
+<script src="js/audio.js?v=51"></script>
+<script src="js/core.js?v=51"></script>
+<script src="js/helpers.js?v=51"></script>
+<script src="js/spawn.js?v=51"></script>
+<script src="js/combat.js?v=51"></script>
+<script src="js/draw.js?v=51"></script>
+<script src="js/hud.js?v=51"></script>
+<script src="js/update_timers.js?v=51"></script>
+<script src="js/update_collision.js?v=51"></script>
+<script src="js/update_enemies.js?v=51"></script>
+<script src="js/update_world.js?v=51"></script>
+<script src="js/update_effects.js?v=51"></script>
+<script src="js/update.js?v=51"></script>
+<script src="js/render.js?v=51"></script>
+<script src="js/achievements.js?v=51"></script>
+<script src="js/shop.js?v=51"></script>
+<script src="js/leaderboard.js?v=51"></script>
+<script src="js/input.js?v=51"></script>
+<script src="js/ui.js?v=51"></script>
+<script src="js/tutorial.js?v=51"></script>
+<script src="js/main.js?v=51"></script>
 </body>
 </html>

--- a/docs/js/update_collision.js
+++ b/docs/js/update_collision.js
@@ -140,7 +140,11 @@ function updateBulletCollisions(g, dtF) {
                     b.x = e.x; b.z = e.z;
                     b.dead = true; b.deathTimer = 3;
                     addExplosion(b.x, b.z);
-                    g.shakeTimer = 8; g.screenFlash = 0.3;
+                    // Floor with Math.max so a sustained rocket barrage
+                    // doesnt erase a larger shake/flash from a recent
+                    // bigger event (mega-boss death, ground slam, etc.).
+                    g.shakeTimer = Math.max(g.shakeTimer, 8);
+                    g.screenFlash = Math.max(g.screenFlash, 0.3);
                     playSound('explosion');
                     g.enemies.forEach(other => {
                         if (!other.alive || other === e) return;


### PR DESCRIPTION
## Summary
`update_collision.js:143` directly assigned shake / flash on every rocket-AOE detonation, dropping any larger ongoing effect down to its values. Most visible when a player fires rockets right after a mega-boss kill — the dramatic shake gets chopped on every blast.

## Fix
`Math.max` floor, matching the pattern used elsewhere (#180, #193, #195). Steady-state behaviour identical.

Cache-buster bumped `?v=50 → v=51`.

## Test plan
- [ ] Fire rockets normally: shake / flash feel unchanged.
- [ ] Mega-boss kill, then immediately fire rockets at adds: dramatic shake stays full duration instead of being chopped to 8 each blast.

Closes #196