### PR TITLE
Floor activate-skill screenFlash with Math.max instead of overwriting, Closes #198

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=51"></script>
-<script src="js/config.js?v=51"></script>
-<script src="js/i18n.js?v=51"></script>
-<script src="js/globals.js?v=51"></script>
-<script src="js/audio.js?v=51"></script>
-<script src="js/core.js?v=51"></script>
-<script src="js/helpers.js?v=51"></script>
-<script src="js/spawn.js?v=51"></script>
-<script src="js/combat.js?v=51"></script>
-<script src="js/draw.js?v=51"></script>
-<script src="js/hud.js?v=51"></script>
-<script src="js/update_timers.js?v=51"></script>
-<script src="js/update_collision.js?v=51"></script>
-<script src="js/update_enemies.js?v=51"></script>
-<script src="js/update_world.js?v=51"></script>
-<script src="js/update_effects.js?v=51"></script>
-<script src="js/update.js?v=51"></script>
-<script src="js/render.js?v=51"></script>
-<script src="js/achievements.js?v=51"></script>
-<script src="js/shop.js?v=51"></script>
-<script src="js/leaderboard.js?v=51"></script>
-<script src="js/input.js?v=51"></script>
-<script src="js/ui.js?v=51"></script>
-<script src="js/tutorial.js?v=51"></script>
-<script src="js/main.js?v=51"></script>
+<script src="js/crypto.js?v=52"></script>
+<script src="js/config.js?v=52"></script>
+<script src="js/i18n.js?v=52"></script>
+<script src="js/globals.js?v=52"></script>
+<script src="js/audio.js?v=52"></script>
+<script src="js/core.js?v=52"></script>
+<script src="js/helpers.js?v=52"></script>
+<script src="js/spawn.js?v=52"></script>
+<script src="js/combat.js?v=52"></script>
+<script src="js/draw.js?v=52"></script>
+<script src="js/hud.js?v=52"></script>
+<script src="js/update_timers.js?v=52"></script>
+<script src="js/update_collision.js?v=52"></script>
+<script src="js/update_enemies.js?v=52"></script>
+<script src="js/update_world.js?v=52"></script>
+<script src="js/update_effects.js?v=52"></script>
+<script src="js/update.js?v=52"></script>
+<script src="js/render.js?v=52"></script>
+<script src="js/achievements.js?v=52"></script>
+<script src="js/shop.js?v=52"></script>
+<script src="js/leaderboard.js?v=52"></script>
+<script src="js/input.js?v=52"></script>
+<script src="js/ui.js?v=52"></script>
+<script src="js/tutorial.js?v=52"></script>
+<script src="js/main.js?v=52"></script>
 </body>
 </html>

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -288,7 +288,7 @@ function activateInvincibility() {
     g.skillCooldown = SKILL_SHARED_COOLDOWN * 1000;
     g.skillReady = false;
     playSound('weapon_pickup');
-    g.screenFlash = 0.4;
+    g.screenFlash = Math.max(g.screenFlash, 0.4);
     g.shakeTimer = Math.max(g.shakeTimer, 6);
     addParticles(g.player.x, g.cameraZ + 10, 15, shopW.colorHex, 4, 20);
 }
@@ -307,7 +307,7 @@ function activateStimulant() {
     g.stimulantTimer = shopW.duration * 1000;
     g.stimulantCooldown = 0;
     playSound('weapon_pickup');
-    g.screenFlash = 0.35;
+    g.screenFlash = Math.max(g.screenFlash, 0.35);
     g.shakeTimer = Math.max(g.shakeTimer, 5);
     addParticles(g.player.x, g.cameraZ + 10, 18, shopW.colorHex, 4, 22);
     g.gateText = { text: '\uD83D\uDC9A STIMULANT! TROOPS x2, DMG HALVED', color: 0x44ff88, timer: 0, maxTimer: 80, scale: 0.1 };


### PR DESCRIPTION
## Summary
`activateInvincibility` and `activateStimulant` already used `Math.max` for the shakeTimer floor but wrote `screenFlash` directly. Asymmetric — and lets a skill activation drop the flash mid-larger-event.

## Fix
Mirror the shake pattern on the flash side. Steady state unchanged.

Cache-buster bumped `?v=51 → v=52`.

## Test plan
- [ ] Press shield/frenzy from steady state: flash looks like before.
- [ ] Press shield/frenzy ~50ms after a mega-boss kill: dramatic flash from the kill is preserved.

Closes #198