### PR TITLE
Floor revive shake/flash with Math.max instead of overwriting, Closes #200

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,30 +308,30 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=52"></script>
-<script src="js/config.js?v=52"></script>
-<script src="js/i18n.js?v=52"></script>
-<script src="js/globals.js?v=52"></script>
-<script src="js/audio.js?v=52"></script>
-<script src="js/core.js?v=52"></script>
-<script src="js/helpers.js?v=52"></script>
-<script src="js/spawn.js?v=52"></script>
-<script src="js/combat.js?v=52"></script>
-<script src="js/draw.js?v=52"></script>
-<script src="js/hud.js?v=52"></script>
-<script src="js/update_timers.js?v=52"></script>
-<script src="js/update_collision.js?v=52"></script>
-<script src="js/update_enemies.js?v=52"></script>
-<script src="js/update_world.js?v=52"></script>
-<script src="js/update_effects.js?v=52"></script>
-<script src="js/update.js?v=52"></script>
-<script src="js/render.js?v=52"></script>
-<script src="js/achievements.js?v=52"></script>
-<script src="js/shop.js?v=52"></script>
-<script src="js/leaderboard.js?v=52"></script>
-<script src="js/input.js?v=52"></script>
-<script src="js/ui.js?v=52"></script>
-<script src="js/tutorial.js?v=52"></script>
-<script src="js/main.js?v=52"></script>
+<script src="js/crypto.js?v=53"></script>
+<script src="js/config.js?v=53"></script>
+<script src="js/i18n.js?v=53"></script>
+<script src="js/globals.js?v=53"></script>
+<script src="js/audio.js?v=53"></script>
+<script src="js/core.js?v=53"></script>
+<script src="js/helpers.js?v=53"></script>
+<script src="js/spawn.js?v=53"></script>
+<script src="js/combat.js?v=53"></script>
+<script src="js/draw.js?v=53"></script>
+<script src="js/hud.js?v=53"></script>
+<script src="js/update_timers.js?v=53"></script>
+<script src="js/update_collision.js?v=53"></script>
+<script src="js/update_enemies.js?v=53"></script>
+<script src="js/update_world.js?v=53"></script>
+<script src="js/update_effects.js?v=53"></script>
+<script src="js/update.js?v=53"></script>
+<script src="js/render.js?v=53"></script>
+<script src="js/achievements.js?v=53"></script>
+<script src="js/shop.js?v=53"></script>
+<script src="js/leaderboard.js?v=53"></script>
+<script src="js/input.js?v=53"></script>
+<script src="js/ui.js?v=53"></script>
+<script src="js/tutorial.js?v=53"></script>
+<script src="js/main.js?v=53"></script>
 </body>
 </html>

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -589,8 +589,8 @@ function revivePlayer() {
     g.state = 'playing';
     g.shieldActive = true;
     g.shieldTimer = 3000;
-    g.screenFlash = 0.6;
-    g.shakeTimer = 10;
+    g.screenFlash = Math.max(g.screenFlash, 0.6);
+    g.shakeTimer = Math.max(g.shakeTimer, 10);
     addParticles(g.player.x, g.cameraZ + 10, 25, 0xcc44ff, 5, 25);
     addParticles(g.player.x, g.cameraZ + 10, 15, 0xffffff, 4, 15);
     g.gateText = { text: `\uD83D\uDC8E REVIVED! TROOPS ${g.squadCount}`, color: 0xcc44ff, timer: 0, maxTimer: 90, scale: 0.1 };


### PR DESCRIPTION
## Summary
`revivePlayer` directly assigned `screenFlash = 0.6` / `shakeTimer = 10`. `update()` halts during the revive state, so any residual shake / flash from the killing blow stays at pre-death values. On revive, the direct assignment can drop those residuals down.

## Fix
`Math.max` floor — the revive cue still applies in steady state, residuals from the killing blow aren't undone.

Same pattern as #180 / #193 / #195 / #197 / #199. Cache-buster bumped `?v=52 → v=53`.

## Test plan
- [ ] Take a regular hit → revive: cue plays normally.
- [ ] Take a mega-boss bullet that drops you → revive immediately: kill-induced shake stays full duration.

Closes #200