### PR TITLE
Remove faint coin / gem pill backgrounds in top HUD, Closes #204

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -308,31 +308,31 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=54"></script>
-<script src="js/config.js?v=54"></script>
-<script src="js/i18n.js?v=54"></script>
-<script src="js/globals.js?v=54"></script>
-<script src="js/audio.js?v=54"></script>
-<script src="js/core.js?v=54"></script>
-<script src="js/helpers.js?v=54"></script>
-<script src="js/spawn.js?v=54"></script>
-<script src="js/combat.js?v=54"></script>
-<script src="js/draw.js?v=54"></script>
-<script src="js/hud.js?v=54"></script>
-<script src="js/update_timers.js?v=54"></script>
-<script src="js/update_collision.js?v=54"></script>
-<script src="js/update_enemies.js?v=54"></script>
-<script src="js/update_world.js?v=54"></script>
-<script src="js/update_effects.js?v=54"></script>
-<script src="js/update.js?v=54"></script>
-<script src="js/render.js?v=54"></script>
-<script src="js/achievements.js?v=54"></script>
-<script src="js/shop.js?v=54"></script>
-<script src="js/leaderboard.js?v=54"></script>
-<script src="js/input.js?v=54"></script>
-<script src="js/ui.js?v=54"></script>
-<script src="js/tutorial.js?v=54"></script>
-<script src="js/main.js?v=54"></script>
-<script src="js/cheat.js?v=54"></script>
+<script src="js/crypto.js?v=55"></script>
+<script src="js/config.js?v=55"></script>
+<script src="js/i18n.js?v=55"></script>
+<script src="js/globals.js?v=55"></script>
+<script src="js/audio.js?v=55"></script>
+<script src="js/core.js?v=55"></script>
+<script src="js/helpers.js?v=55"></script>
+<script src="js/spawn.js?v=55"></script>
+<script src="js/combat.js?v=55"></script>
+<script src="js/draw.js?v=55"></script>
+<script src="js/hud.js?v=55"></script>
+<script src="js/update_timers.js?v=55"></script>
+<script src="js/update_collision.js?v=55"></script>
+<script src="js/update_enemies.js?v=55"></script>
+<script src="js/update_world.js?v=55"></script>
+<script src="js/update_effects.js?v=55"></script>
+<script src="js/update.js?v=55"></script>
+<script src="js/render.js?v=55"></script>
+<script src="js/achievements.js?v=55"></script>
+<script src="js/shop.js?v=55"></script>
+<script src="js/leaderboard.js?v=55"></script>
+<script src="js/input.js?v=55"></script>
+<script src="js/ui.js?v=55"></script>
+<script src="js/tutorial.js?v=55"></script>
+<script src="js/main.js?v=55"></script>
+<script src="js/cheat.js?v=55"></script>
 </body>
 </html>

--- a/docs/js/hud.js
+++ b/docs/js/hud.js
@@ -48,19 +48,6 @@ function updateHUD() {
     rect(screenW / 2 - hs / 2, 10, 1, 38);
     rect(screenW / 2 + hs / 2, 10, 1, 38);
 
-    // Coin pill (right)
-    const pillW = 82, pillH = 22, pillR = 11;
-    hexFill(0xffd700, Math.floor(0.1 * 255)); noStroke();
-    rect(screenW / 2 + hs - pillW / 2, 38, pillW, pillH, pillR);
-    hexStroke(0xffd700, Math.floor(0.2 * 255)); strokeWeight(1); noFill();
-    rect(screenW / 2 + hs - pillW / 2, 38, pillW, pillH, pillR);
-
-    // Gem pill (left)
-    hexFill(0xcc44ff, Math.floor(0.1 * 255)); noStroke();
-    rect(screenW / 2 - hs - pillW / 2, 38, pillW, pillH, pillR);
-    hexStroke(0xcc44ff, Math.floor(0.2 * 255)); strokeWeight(1); noFill();
-    rect(screenW / 2 - hs - pillW / 2, 38, pillW, pillH, pillR);
-
     // XP bar
     const lvl = Math.min(g.level, LEVEL_CONFIG.maxLevel);
     const isMaxLvl = lvl >= LEVEL_CONFIG.maxLevel;


### PR DESCRIPTION
## Summary
`hud.js:51-62` drew two faint rounded-rectangle pills (yellow ~10% alpha behind the coin count, purple ~10% alpha behind the gem count). User flagged them as unnecessary clutter — the icon + number is plenty legible against the existing dark HUD panel.

## Fix
Drop both pill blocks. `_hudText` calls at lines 93-95 (coin / gem) still render at the same coordinates, just without the capsule behind them.

Cache-buster bumped `?v=54 → v=55`.

## Test plan
- [ ] Hard-refresh, start any level: top-center HUD shows the dark panel body, score / squad / wave text, the coin and gem counts — but no faint capsules behind the numbers.
- [ ] XP bar at the bottom of the HUD still draws correctly.

Closes #204