### PR TITLE
Remove production cheat panel

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -339,6 +339,5 @@ body > canvas {
 <script src="js/ui.js?v=55"></script>
 <script src="js/tutorial.js?v=55"></script>
 <script src="js/main.js?v=55"></script>
-<script src="js/cheat.js?v=55"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Removes the unconditional production load of `docs/js/cheat.js`
- Prevents the hidden modifier panel from being available in the deployed game by default
- Keeps the normal game module loading order unchanged

Closes #206

## Testing

- Ran `git diff --check`
- Confirmed `cheat.js` is no longer referenced from `docs/index.html`
