### PR TITLE
Validate score / wave range unconditionally in leaderboard hook, Closes #210

### DIFF
--- a/infra/pocketbase/pb_hooks/game_scores.pb.js
+++ b/infra/pocketbase/pb_hooks/game_scores.pb.js
@@ -2,15 +2,33 @@
 
 // PB v0.22+ goja runs each onXxx callback in its own eval scope, so
 // helpers MUST be inlined inside the callback (top-level functions are
-// invisible there). Token is treated as optional: if X-Game-Token header
-// is present, validated strictly; if missing, the write is allowed
-// through. Once the front-end ships matching client-side HMAC signing
-// the same callback enforces it without further server changes.
+// invisible there).
+//
+// Two layers of validation:
+//   1. Range check on score / wave runs UNCONDITIONALLY on every write,
+//      so a malicious client can't post wave=1e20 even without the
+//      X-Game-Token header (real example: the '元神' row pre-rangefix).
+//   2. Optional HMAC check: if X-Game-Token is present, validate strictly;
+//      if missing, the write is allowed through (front-end currently does
+//      not sign — keeps door open for adding signing later without a
+//      breaking server change).
 
 onRecordCreateRequest((e) => {
     const LB_SECRET = "badger_bridge_assault_score_v2x7";
     const MAX_SCORE_PER_WAVE = 3000;
 
+    const score = Math.floor(Number(e.record.get("score")) || 0);
+    const wave  = Math.floor(Number(e.record.get("wave"))  || 0);
+
+    // (1) unconditional bounds — catches malformed / fabricated data
+    if (wave < 0 || wave > 1999) throw new BadRequestError("Invalid wave");
+    const actualWave = wave >= 1000 ? wave - 1000 : wave;
+    if (actualWave < 0 || actualWave > 999) throw new BadRequestError("Invalid wave");
+    if (score < 0) throw new BadRequestError("Invalid score");
+    const maxScore = Math.max(actualWave, 1) * MAX_SCORE_PER_WAVE;
+    if (score > maxScore) throw new BadRequestError("Score out of range");
+
+    // (2) optional HMAC token — strict if present, ignored if absent
     let token = null;
     try {
         if (e && e.request && e.request.header && typeof e.request.header.get === "function") {
@@ -25,16 +43,7 @@ onRecordCreateRequest((e) => {
             }
         } catch (_) {}
     }
-
     if (token) {
-        const score = Math.floor(Number(e.record.get("score")) || 0);
-        const wave  = Math.floor(Number(e.record.get("wave"))  || 0);
-        if (wave < 0 || wave > 1999) throw new BadRequestError("Invalid wave");
-        const actualWave = wave >= 1000 ? wave - 1000 : wave;
-        if (actualWave < 0 || actualWave > 999) throw new BadRequestError("Invalid wave");
-        if (score < 0) throw new BadRequestError("Invalid score");
-        const maxScore = Math.max(actualWave, 1) * MAX_SCORE_PER_WAVE;
-        if (score > maxScore) throw new BadRequestError("Score out of range");
         const expected = $security.hs256(score + "|" + wave, LB_SECRET).substring(0, 32);
         if (token !== expected) throw new BadRequestError("Invalid token");
     }
@@ -45,6 +54,16 @@ onRecordUpdateRequest((e) => {
     const LB_SECRET = "badger_bridge_assault_score_v2x7";
     const MAX_SCORE_PER_WAVE = 3000;
 
+    const score = Math.floor(Number(e.record.get("score")) || 0);
+    const wave  = Math.floor(Number(e.record.get("wave"))  || 0);
+
+    if (wave < 0 || wave > 1999) throw new BadRequestError("Invalid wave");
+    const actualWave = wave >= 1000 ? wave - 1000 : wave;
+    if (actualWave < 0 || actualWave > 999) throw new BadRequestError("Invalid wave");
+    if (score < 0) throw new BadRequestError("Invalid score");
+    const maxScore = Math.max(actualWave, 1) * MAX_SCORE_PER_WAVE;
+    if (score > maxScore) throw new BadRequestError("Score out of range");
+
     let token = null;
     try {
         if (e && e.request && e.request.header && typeof e.request.header.get === "function") {
@@ -59,16 +78,7 @@ onRecordUpdateRequest((e) => {
             }
         } catch (_) {}
     }
-
     if (token) {
-        const score = Math.floor(Number(e.record.get("score")) || 0);
-        const wave  = Math.floor(Number(e.record.get("wave"))  || 0);
-        if (wave < 0 || wave > 1999) throw new BadRequestError("Invalid wave");
-        const actualWave = wave >= 1000 ? wave - 1000 : wave;
-        if (actualWave < 0 || actualWave > 999) throw new BadRequestError("Invalid wave");
-        if (score < 0) throw new BadRequestError("Invalid score");
-        const maxScore = Math.max(actualWave, 1) * MAX_SCORE_PER_WAVE;
-        if (score > maxScore) throw new BadRequestError("Score out of range");
         const expected = $security.hs256(score + "|" + wave, LB_SECRET).substring(0, 32);
         if (token !== expected) throw new BadRequestError("Invalid token");
     }


### PR DESCRIPTION
## Summary
After #209 made the X-Game-Token optional, range validation got dragged inside the `if (token)` block — which means with no token sent (i.e. always today), wave / score bounds checks were also skipped. Live DB confirmed: one row had `wave = 1e20`.

Hoist the bounds out of the token block so they run on every write. Token still gates strict HMAC (kept ready for future client-side signing).

## Behaviour matrix (verified live with curl)
| Payload | Status |
|---|---|
| `{score:1234, wave:5}` | 200 |
| `{score:100, wave:99999}` | 400 |
| `{score:999999, wave:1}` | 400 |
| `{score:-1, wave:1}` | 400 |

## Cleanup applied to live DB
- Deleted the `元神 / wave=1e20` row (only pre-existing out-of-range record)
- Deleted my smoke-test row
- 18 real records remain (yangyusheng, 天诛丸, etc.)

Already deployed via `scp` + `sudo systemctl restart pocketbase`. Backup at `pb_hooks/game_scores.pb.js.bak.20260427-rangefix` on the server.

Closes #210