### PR TITLE
Block leaderboard sync from cheat-tainted saves, Closes #212

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
 <link rel="icon" type="image/png" href="assets/favicon.png">
-<link rel="stylesheet" href="style.css?v=22">
+<link rel="stylesheet" href="style.css?v=23">
 <style>
 /* p5.js 1.11 wraps the default canvas in body > main. Keep that main
    canvas fixed behind overlays without touching level-select mini-canvases. */
@@ -314,31 +314,31 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=55"></script>
-<script src="js/config.js?v=55"></script>
-<script src="js/i18n.js?v=55"></script>
-<script src="js/globals.js?v=55"></script>
-<script src="js/audio.js?v=55"></script>
-<script src="js/core.js?v=55"></script>
-<script src="js/helpers.js?v=55"></script>
-<script src="js/spawn.js?v=55"></script>
-<script src="js/combat.js?v=55"></script>
-<script src="js/draw.js?v=55"></script>
-<script src="js/hud.js?v=55"></script>
-<script src="js/update_timers.js?v=55"></script>
-<script src="js/update_collision.js?v=55"></script>
-<script src="js/update_enemies.js?v=55"></script>
-<script src="js/update_world.js?v=55"></script>
-<script src="js/update_effects.js?v=55"></script>
-<script src="js/update.js?v=55"></script>
-<script src="js/render.js?v=55"></script>
-<script src="js/achievements.js?v=55"></script>
-<script src="js/shop.js?v=55"></script>
-<script src="js/leaderboard.js?v=55"></script>
-<script src="js/input.js?v=55"></script>
-<script src="js/ui.js?v=55"></script>
-<script src="js/tutorial.js?v=55"></script>
-<script src="js/main.js?v=55"></script>
-<script src="js/cheat.js?v=55"></script>
+<script src="js/crypto.js?v=56"></script>
+<script src="js/config.js?v=56"></script>
+<script src="js/i18n.js?v=56"></script>
+<script src="js/globals.js?v=56"></script>
+<script src="js/audio.js?v=56"></script>
+<script src="js/core.js?v=56"></script>
+<script src="js/helpers.js?v=56"></script>
+<script src="js/spawn.js?v=56"></script>
+<script src="js/combat.js?v=56"></script>
+<script src="js/draw.js?v=56"></script>
+<script src="js/hud.js?v=56"></script>
+<script src="js/update_timers.js?v=56"></script>
+<script src="js/update_collision.js?v=56"></script>
+<script src="js/update_enemies.js?v=56"></script>
+<script src="js/update_world.js?v=56"></script>
+<script src="js/update_effects.js?v=56"></script>
+<script src="js/update.js?v=56"></script>
+<script src="js/render.js?v=56"></script>
+<script src="js/achievements.js?v=56"></script>
+<script src="js/shop.js?v=56"></script>
+<script src="js/leaderboard.js?v=56"></script>
+<script src="js/input.js?v=56"></script>
+<script src="js/ui.js?v=56"></script>
+<script src="js/tutorial.js?v=56"></script>
+<script src="js/main.js?v=56"></script>
+<script src="js/cheat.js?v=56"></script>
 </body>
 </html>

--- a/docs/js/cheat.js
+++ b/docs/js/cheat.js
@@ -15,6 +15,21 @@
     let _liveTickHandle = null;
     let _configDefaults = null;
 
+    // Mark this save as 'cheat tainted' on first modification so the
+    // leaderboard sync logic can refuse to publish modder runs. Idempotent —
+    // safe to call from every write/toggle path.
+    function _markCheatUsed() {
+        if (typeof playerData === 'undefined' || !playerData) return;
+        if (playerData.cheatTainted) return;
+        playerData.cheatTainted = true;
+        try {
+            if (typeof savePlayerData === 'function') savePlayerData(playerData);
+        } catch (_) {}
+        try {
+            if (typeof flushPlayerDataSave === 'function') flushPlayerDataSave(true);
+        } catch (_) {}
+    }
+
     // Persistent live-cheat flags (kept in memory, not saved)
     const live = {
         godMode: false,
@@ -390,12 +405,12 @@
                 ])}
             `)}
             ${_section('无敌 / 自动补给', `
-                ${_chkRow('🛡️ 无敌模式（持续护盾）', live.godMode, v => { live.godMode = v; _applyGodMode(v); })}
-                ${_chkRow('♾️ 技能充能不消耗', live.infiniteCharges, v => { live.infiniteCharges = v; })}
-                ${_chkRow('💰 自动补金币 (每秒+50)', live.autoCoins, v => { live.autoCoins = v; })}
-                ${_chkRow('💎 自动补宝石 (每秒+5)', live.autoGems, v => { live.autoGems = v; })}
-                ${_chkRow('💀 一击必杀（敌人 hp 持续清零）', live.oneShotKill, v => { live.oneShotKill = v; })}
-                ${_chkRow('⏸ 冻结波次推进', live.freezeWave, v => { live.freezeWave = v; })}
+                ${_chkRow('🛡️ 无敌模式（持续护盾）', live.godMode, v => { live.godMode = v; _applyGodMode(v); if (v) _markCheatUsed(); })}
+                ${_chkRow('♾️ 技能充能不消耗', live.infiniteCharges, v => { live.infiniteCharges = v; if (v) _markCheatUsed(); })}
+                ${_chkRow('💰 自动补金币 (每秒+50)', live.autoCoins, v => { live.autoCoins = v; if (v) _markCheatUsed(); })}
+                ${_chkRow('💎 自动补宝石 (每秒+5)', live.autoGems, v => { live.autoGems = v; if (v) _markCheatUsed(); })}
+                ${_chkRow('💀 一击必杀（敌人 hp 持续清零）', live.oneShotKill, v => { live.oneShotKill = v; if (v) _markCheatUsed(); })}
+                ${_chkRow('⏸ 冻结波次推进', live.freezeWave, v => { live.freezeWave = v; if (v) _markCheatUsed(); })}
             `)}
             ${_section('伤害与射速倍率', `
                 <div class="cheat-row">
@@ -435,10 +450,14 @@
         }
     }
 
-    window._cheatLive = (k, v) => { live[k] = v; };
+    // For sliders: only mark tainted when the value diverges from the
+    // neutral 1.0× default, so just opening the panel and dragging back
+    // to default doesnt permanently taint the save.
+    window._cheatLive = (k, v) => { live[k] = v; if (v !== 1.0) _markCheatUsed(); };
 
     window._cheatKillAllEnemies = () => {
         if (!game || !game.enemies) return;
+        _markCheatUsed();
         game.enemies.forEach(e => { e.hp = 0; e.alive = false; });
         _render();
     };
@@ -451,6 +470,7 @@
     };
     window._cheatSpawnBoss = () => {
         if (!game) return;
+        _markCheatUsed();
         // Trigger the existing boss spawn helper if it exists
         if (typeof spawnBoss === 'function') { spawnBoss(); return; }
         // Fallback: nudge wave to a boss-trigger wave
@@ -461,26 +481,31 @@
     };
     window._cheatNextWave = () => {
         if (!game) return;
+        _markCheatUsed();
         game.wave = (game.wave || 1) + 1;
         _render();
     };
     window._cheatJumpWave = (n) => {
         if (!game) return;
+        _markCheatUsed();
         game.wave = (game.wave || 1) + n;
         _render();
     };
     window._cheatActivateShield = () => {
         if (!game) return;
+        _markCheatUsed();
         game.shieldActive = true;
         game.shieldTimer = 30000;
     };
     window._cheatActivateFrenzy = () => {
         if (!game) return;
+        _markCheatUsed();
         game.stimulantActive = true;
         game.stimulantTimer = 30000;
     };
     window._cheatHealAll = () => {
         if (!game) return;
+        _markCheatUsed();
         game.squadCount = Math.max(game.squadCount || 0, game.peakSquad || 50);
         if (game.squadCount < 50) game.squadCount = 50;
         game.peakSquad = Math.max(game.peakSquad || 0, game.squadCount);
@@ -823,6 +848,9 @@
 
     function _markDirty() {
         try { if (typeof markPlayerDataDirty === 'function') markPlayerDataDirty(); } catch {}
+        // Every cheat write path goes through _markDirty, so this is the
+        // single chokepoint that flips the cheat-tainted flag.
+        _markCheatUsed();
     }
 
     function _toast(msg) {

--- a/docs/js/globals.js
+++ b/docs/js/globals.js
@@ -139,4 +139,8 @@ if (!playerData.achievementsClaimed) playerData.achievementsClaimed = {};
 if (playerData.hasSeenTutorial === undefined) playerData.hasSeenTutorial = false;
 if (playerData.tutorialRewardClaimed === undefined) playerData.tutorialRewardClaimed = false;
 if (playerData.tutorialRewardChoice === undefined) playerData.tutorialRewardChoice = '';
+// Set true once any modifier (cheat panel) action runs against this save.
+// Once true, leaderboard sync is permanently blocked for this save to keep
+// modder runs out of the public ranking.
+if (playerData.cheatTainted === undefined) playerData.cheatTainted = false;
 savePlayerData(playerData);

--- a/docs/js/i18n.js
+++ b/docs/js/i18n.js
@@ -459,6 +459,8 @@ const TRANSLATIONS = {
         'lb.hidden.notice':    '你的分数当前是私密状态，不会出现在公开榜单中',
         'lb.close':            '关闭',
         'lb.leaderboard.btn':  '🏆 天梯榜',
+        'lb.tainted.title':    '此存档已使用修改器',
+        'lb.tainted.body':     '为了天梯榜的公平性，使用过修改器的存档不会同步分数到公开榜单。这是不可恢复的——重置存档后即可重新参加排名。',
     },
 
     en: {
@@ -812,6 +814,8 @@ const TRANSLATIONS = {
         'lb.hidden.notice':    'Your score is currently private and will not appear on the public leaderboard',
         'lb.close':            'Close',
         'lb.leaderboard.btn':  '🏆 Leaderboard',
+        'lb.tainted.title':    'Modifier was used on this save',
+        'lb.tainted.body':     'To keep the leaderboard fair, saves that used the modifier panel cannot sync scores to the public ranking. This is permanent — reset your save to re-enter the ranking.',
     },
 };
 

--- a/docs/js/leaderboard.js
+++ b/docs/js/leaderboard.js
@@ -89,6 +89,10 @@ async function _fetchMyRank(myScore) {
 
 // ── Sync high score (fire-and-forget after game over) ─────────
 async function syncHighScore() {
+    // Refuse to publish runs from a save tainted by the cheat panel —
+    // keeps modder scores out of the public ranking. Once flipped, this
+    // flag is sticky on this save (cheating in one run doesnt expire).
+    if (playerData && playerData.cheatTainted) return;
     const player = getLbPlayer();
     if (!player || player.hidden) return; // skip if player hid themselves
     const hs = _getLeaderboardBestScore();
@@ -151,6 +155,10 @@ function showLeaderboard() {
     const el = document.getElementById('leaderboardOverlay');
     if (!el) return;
     el.classList.remove('hidden');
+    if (playerData && playerData.cheatTainted) {
+        _renderTaintedNotice();
+        return;
+    }
     const player = getLbPlayer();
     if (player) {
         if (!player.hidden) syncHighScore(); // sync before showing
@@ -158,6 +166,22 @@ function showLeaderboard() {
     } else {
         _renderJoinForm();
     }
+}
+
+function _renderTaintedNotice() {
+    const panel = document.getElementById('leaderboardPanel');
+    if (!panel) return;
+    panel.innerHTML = `
+        <div id="leaderboardTitle">${T('lb.title')}</div>
+        <div class="lb-tainted">
+            <div class="lb-tainted-icon">⚠️</div>
+            <div class="lb-tainted-title">${T('lb.tainted.title')}</div>
+            <div class="lb-tainted-body">${T('lb.tainted.body')}</div>
+        </div>
+        <div class="lb-join-btns">
+            <button class="btn lb-btn-close" onclick="hideLeaderboard()">${T('lb.close')}</button>
+        </div>
+    `;
 }
 
 function hideLeaderboard() {
@@ -187,6 +211,10 @@ function _renderJoinForm() {
 }
 
 async function _handleJoin() {
+    if (playerData && playerData.cheatTainted) {
+        _renderTaintedNotice();
+        return;
+    }
     const input = document.getElementById('lbJoinInput');
     const statusEl = document.getElementById('lbJoinStatus');
     const btn = document.getElementById('lbJoinBtn');

--- a/docs/style.css
+++ b/docs/style.css
@@ -1597,6 +1597,34 @@ body::after {
     margin-top: 4px;
 }
 
+/* ── Cheat-tainted notice (replaces join form when playerData.cheatTainted) ── */
+.lb-tainted {
+    text-align: center;
+    padding: min(24px, 4vh) min(20px, 4vw);
+    border-radius: 14px;
+    background: rgba(180, 60, 60, 0.10);
+    border: 1px solid rgba(255, 120, 120, 0.35);
+    margin: min(18px, 3vh) 0 min(18px, 3vh);
+    color: #f4d8d8;
+}
+.lb-tainted-icon {
+    font-size: min(36px, 7vw);
+    margin-bottom: 8px;
+}
+.lb-tainted-title {
+    font-family: 'Courier New', monospace;
+    font-weight: bold;
+    color: #ff9090;
+    font-size: min(17px, 3.6vw);
+    letter-spacing: 1px;
+    margin-bottom: 10px;
+}
+.lb-tainted-body {
+    font-size: min(13px, 2.9vw);
+    line-height: 1.7;
+    color: #d8c4c4;
+}
+
 /* ── Join form (inside leaderboard panel) ── */
 .lb-join-desc {
     text-align: center;


### PR DESCRIPTION
## Summary
The modifier panel (`cheat.js`) lets a player edit coins, gems, talents, weapon levels, toggle god mode / time scale / 20× damage / instant kills, etc. The range hook from #210 only catches fabricated payloads (wave > 1999, score > 3000 × wave); a modder running god mode + buffs easily produces *legitimate-looking* numbers that pass the bounds check.

Client-side HMAC was considered but the secret would have to embed in the front-end JS, and DevTools Sources reveals it. **Tainted-save** is simpler and bounds the threat to hand-edited localStorage:

1. **`globals.js`** — migrate `playerData.cheatTainted` (default `false`).
2. **`cheat.js`** — single chokepoint `_markCheatUsed()` called from `_markDirty` (every persistent write) + each `window._cheatXxx` game-state action + live-tab toggles when activated. Slider sentinels: only mark tainted when value ≠ 1.0 default, so opening the panel and dragging back is harmless.
3. **`leaderboard.js`** — `syncHighScore` / `_handleJoin` early-return when tainted; `showLeaderboard` shows a red-tinted "Modifier was used" notice instead of the join / list panels.
4. **`i18n.js`** — `lb.tainted.title` / `lb.tainted.body` (zh + en).
5. **`style.css`** — `.lb-tainted*` styling.

Cache-buster `?v=55 → v=56`, `style.css?v=22 → v=23`.

## Behaviour
- Fresh save: leaderboard works exactly as before.
- Player toggles **anything** in cheat panel that affects gameplay → `cheatTainted = true` persisted immediately.
- From that point: leaderboard sync silently refused; the leaderboard UI shows the tainted notice with copy explaining "reset save to re-enter ranking".
- Player can keep playing with cheats — only the public ranking is blocked.

## Test plan
- [ ] Fresh save: leaderboard join / sync works.
- [ ] Open cheat panel, click "+10 coins": tainted notice appears next time leaderboard opens.
- [ ] Toggle god mode in live tab: same.
- [ ] Drag damage slider to 1.0 then back to 1.0: NOT tainted (slider sentinel).
- [ ] Reload after tainting: still tainted (persisted).
- [ ] No console errors when leaderboard opens on a tainted save.

Closes #212