### PR TITLE
Add /api/leaderboard and /api/fw REST endpoints

### DIFF
--- a/docs/js/leaderboard.js
+++ b/docs/js/leaderboard.js
@@ -14,6 +14,31 @@ function _lbEscape(str) {
         .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
+// ── Forbidden word list (must match server-side list) ─────────
+// Player names containing these substrings will be masked with "**".
+const _FORBIDDEN_WORDS = [
+    '傻逼', 'sb', '垃圾', '废物', '狗', '操', 'fuck',
+    '他妈', '特么', '草泥马', '屌', '婊',
+    'cao', 'shit', 'asshole', 'nmsl', 'cnm', 'tmd', 'md', 'wqnmlgb'
+];
+
+function _censorName(name) {
+    const n = String(name || '');
+    var result = n;
+    var lower = result.toLowerCase();
+    for (var i = 0; i < _FORBIDDEN_WORDS.length; i++) {
+        var w = _FORBIDDEN_WORDS[i].toLowerCase();
+        if (!w) continue;
+        while (true) {
+            var idx = lower.indexOf(w);
+            if (idx === -1) break;
+            result = result.substring(0, idx) + '**' + result.substring(idx + w.length);
+            lower = result.toLowerCase();
+        }
+    }
+    return result;
+}
+
 // ── localStorage ──────────────────────────────────────────────
 function getLbPlayer() {
     try { const r = localStorage.getItem(LB_STORAGE_KEY); return r ? JSON.parse(r) : null; } catch { return null; }
@@ -249,9 +274,10 @@ async function _renderList(myName) {
             const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : `${i + 1}`;
             const isMe = myName && item.player_name === myName;
             const lv = item.level || 1;
+            const dispName = _censorName(item.player_name);
             return `<div class="lb-row${i < 3 ? ' lb-top3' : ''}${isMe ? ' lb-mine' : ''}">
                 <span class="lb-rank">${medal}</span>
-                <span class="lb-name">${_lbEscape(item.player_name)}</span>
+                <span class="lb-name">${_lbEscape(dispName)}</span>
                 <span class="lb-level">Lv.${lv}</span>
                 <span class="lb-score">${item.score.toLocaleString()}</span>
                 <span class="lb-wave">W${item.wave}</span>
@@ -266,7 +292,7 @@ async function _renderList(myName) {
                 const lv = hs.level || (playerData ? Math.floor(playerData.level || 1) : 1);
                 html += `<div class="lb-row lb-mine">
                     <span class="lb-rank" style="color:#888">--</span>
-                    <span class="lb-name">${_lbEscape(myName)}</span>
+                    <span class="lb-name">${_lbEscape(_censorName(myName))}</span>
                     <span class="lb-level">Lv.${lv}</span>
                     <span class="lb-score">${hs.score > 0 ? hs.score.toLocaleString() : '--'}</span>
                     <span class="lb-wave">${hs.wave > 0 ? 'W'+hs.wave : '--'}</span>
@@ -280,7 +306,7 @@ async function _renderList(myName) {
                         const myMedal = myRank === 1 ? '🥇' : myRank === 2 ? '🥈' : myRank === 3 ? '🥉' : `${myRank}`;
                         html += `<div class="lb-row lb-mine">
                             <span class="lb-rank">${myMedal}</span>
-                            <span class="lb-name">${_lbEscape(myName)}</span>
+                            <span class="lb-name">${_lbEscape(_censorName(myName))}</span>
                             <span class="lb-level">Lv.${lv}</span>
                             <span class="lb-score">${hs.score.toLocaleString()}</span>
                             <span class="lb-wave">W${hs.wave}</span>

--- a/infra/pocketbase/pb_hooks/game_scores.pb.js
+++ b/infra/pocketbase/pb_hooks/game_scores.pb.js
@@ -84,3 +84,153 @@ onRecordUpdateRequest((e) => {
     }
     e.next();
 }, "game_scores");
+
+// ── Forbidden word censorship on record enrich ───────────────
+// Applied when records are returned to clients (list/view), so even if
+// somebody sneaks past the create hook, the rendered name is masked.
+
+onRecordEnrich((e) => {
+    const FORBIDDEN = ["傻逼","sb","垃圾","废物","狗","操","fuck","他妈","特么","草泥马","屌","婊","cao","shit","asshole","nmsl","cnm","tmd","md","wqnmlgb"];
+    let name = String(e.record.get("player_name") || "");
+    if (!name) { e.next(); return; }
+    let lower = name.toLowerCase();
+    for (let i = 0; i < FORBIDDEN.length; i++) {
+        const w = FORBIDDEN[i];
+        let idx;
+        while ((idx = lower.indexOf(w)) !== -1) {
+            name = name.substring(0, idx) + "**" + name.substring(idx + w.length);
+            lower = name.toLowerCase();
+        }
+    }
+    e.record.set("player_name", name);
+    e.next();
+}, "game_scores");
+
+// ── Custom REST API: GET /api/fw ──────────────────────────────
+// Returns the forbidden words list so the front-end can mirror the
+// server-side mask. Curl: curl https://www.lzqqq.org/pb/api/fw
+
+routerAdd("GET", "/api/fw", (e) => {
+    const FORBIDDEN = ["傻逼","sb","垃圾","废物","狗","操","fuck","他妈","特么","草泥马","屌","婊","cao","shit","asshole","nmsl","cnm","tmd","md","wqnmlgb"];
+    // We hand-marshal with JSON.stringify so the key order (count, then
+    // words) is preserved and the body is indented. Go's encoding/json
+    // would otherwise sort map keys alphabetically and produce one line.
+    const body = {
+        count: FORBIDDEN.length,
+        words: FORBIDDEN,
+    };
+    const h = e.response.header();
+    h.set("Content-Type", "application/json; charset=utf-8");
+    h.set("Access-Control-Allow-Origin", "*");
+    h.set("Cache-Control", "public, max-age=300");
+    return e.string(200, JSON.stringify(body, null, 2));
+});
+
+// ── Custom REST API: GET /api/leaderboard ────────────────────
+// Top visible players with rank + overall stats.
+//   ?limit=N (default 10, max 100)
+// Curl: curl 'https://www.lzqqq.org/pb/api/leaderboard?limit=20'
+
+routerAdd("GET", "/api/leaderboard", (e) => {
+    const FORBIDDEN = ["傻逼","sb","垃圾","废物","狗","操","fuck","他妈","特么","草泥马","屌","婊","cao","shit","asshole","nmsl","cnm","tmd","md","wqnmlgb"];
+    e.response.header().set("Access-Control-Allow-Origin", "*");
+    e.response.header().set("Cache-Control", "public, max-age=10");
+
+    let limit = 10;
+    try {
+        const info = e.requestInfo();
+        const q = (info && info.query) || {};
+        const n = parseInt(q.limit, 10);
+        if (!isNaN(n) && n > 0) limit = Math.min(n, 100);
+    } catch (_) {}
+
+    // PB v0.23+ exposes find/count on $app directly; v0.22 keeps them on
+    // $app.dao(). Probe both so the same hook works either way.
+    const dao =
+        (typeof $app.findRecordsByFilter === "function") ? $app :
+        (typeof $app.dao === "function") ? $app.dao() : null;
+    if (!dao || typeof dao.findRecordsByFilter !== "function") {
+        return e.json(500, {
+            error: "no findRecordsByFilter available",
+            has_dao: typeof $app.dao,
+            has_find: typeof $app.findRecordsByFilter,
+        });
+    }
+
+    const debug = {};
+    let records = [];
+    try {
+        // Tiebreak by +id: PB ids are ULIDs (monotonic), so smaller id =
+        // earlier submission. The collection has no `created` field.
+        records = dao.findRecordsByFilter(
+            "game_scores",
+            "hidden = false",
+            "-score,+id",
+            limit,
+            0
+        ) || [];
+    } catch (err) {
+        debug.find_visible_err = String(err);
+    }
+
+    // Best-effort stats. countRecords is v0.23+ only; on older PB we
+    // fall back to a coarse "find all then length" count.
+    let totalAll = 0, visibleAll = 0;
+    if (typeof dao.countRecords === "function") {
+        try { totalAll = dao.countRecords("game_scores"); }
+        catch (err) { debug.count_total_err = String(err); }
+        try { visibleAll = dao.countRecords("game_scores", $dbx.exp("hidden = false")); }
+        catch (err) { debug.count_visible_err = String(err); }
+    } else {
+        try {
+            const all = dao.findRecordsByFilter("game_scores", "", "", 5000, 0) || [];
+            totalAll = all.length;
+            visibleAll = 0;
+            for (let i = 0; i < all.length; i++) {
+                if (!all[i].get("hidden")) visibleAll++;
+            }
+        } catch (err) { debug.count_fallback_err = String(err); }
+    }
+
+    const items = [];
+    for (let i = 0; i < records.length; i++) {
+        const r = records[i];
+        let name = String(r.get("player_name") || "");
+        let lower = name.toLowerCase();
+        for (let k = 0; k < FORBIDDEN.length; k++) {
+            const w = FORBIDDEN[k];
+            let idx;
+            while ((idx = lower.indexOf(w)) !== -1) {
+                name = name.substring(0, idx) + "**" + name.substring(idx + w.length);
+                lower = name.toLowerCase();
+            }
+        }
+        items.push({
+            rank: i + 1,
+            player_name: name,
+            score: r.get("score"),
+            wave: r.get("wave"),
+            level: r.get("level") || 1,
+        });
+    }
+
+    const body = {
+        stats: {
+            total:   totalAll,
+            visible: visibleAll,
+            hidden:  Math.max(0, totalAll - visibleAll),
+        },
+        top: items,
+    };
+    // Surface debug only if something actually failed, so happy-path
+    // responses stay clean.
+    let hasDebug = false;
+    for (const k in debug) { hasDebug = true; break; }
+    if (hasDebug) body.debug = debug;
+
+    // Hand-marshal so insertion order is preserved (stats first, then
+    // top) and the body is indented. e.json would alphabetize keys.
+    const h = e.response.header();
+    h.set("Content-Type", "application/json; charset=utf-8");
+    return e.string(200, JSON.stringify(body, null, 2));
+});


### PR DESCRIPTION
## Summary

- `GET /api/leaderboard?limit=N` — top visible scores with rank, plus total / visible / hidden counts. Queries the `game_scores` collection directly via `$app.findRecordsByFilter`; sorts by `-score, +id` (the collection has no `created` field).
- `GET /api/fw` — exposes the forbidden-words list so the front-end can mirror the server-side mask without drifting.
- `onRecordEnrich` masks `player_name` on every read path against the same word list (inlined inside the callback because goja's eval-scope hides top-level helpers).
- Responses hand-marshalled with `JSON.stringify(_, null, 2)` so curl gets indented output with business-meaningful key order (`stats` first, then `top`; `rank → player_name → score → wave → level` inside items) instead of Go's alphabetical map sort.
- CORS + `Cache-Control` headers added so browser fetch can hit the routes too.

Front-end mirrors the same forbidden-word list in `docs/js/leaderboard.js` and masks names locally as defence-in-depth.

## Test plan

- [x] `curl https://www.lzqqq.org/pb/api/fw` returns 20-word list, indented
- [x] `curl 'https://www.lzqqq.org/pb/api/leaderboard?limit=20'` returns ranked top + stats `{total:21, visible:15, hidden:6}`
- [x] `onRecordEnrich` masking verified via `/api/collections/game_scores/records` (`xyc是**`)
- [ ] Reviewer to redeploy hook to VM: `scp infra/pocketbase/pb_hooks/game_scores.pb.js myserver:/home/ubuntu/pocketbase/pb_hooks/ && ssh myserver 'sudo systemctl restart pocketbase'`