### PR TITLE
docs: fix mermaid sequence diagram parse error + add ui.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ The runtime currently spans 26 JavaScript modules under `docs/js/`. The table gr
 | `docs/js/draw.js` | 3D perspective rendering and sprite drawing |
 | `docs/js/render.js` | UI rendering, HUD, in-world text |
 | `docs/js/hud.js` | In-game UI (HP bars, popup text, combo counters) |
+| `docs/js/ui.js` | Pause menu, level select, game lifecycle, skill / weapon-slot UI, revive and game-over overlays, debug overlay |
 | `docs/js/shop.js` | Permanent shop, weapon purchases, talents, mid-run shop UI |
 | `docs/js/achievements.js` | Achievement definitions, tracking, claiming, notifications |
 | `docs/js/leaderboard.js` | PocketBase leaderboard connection, hide/show, score sync |
@@ -400,16 +401,16 @@ The `Game` aggregate is the global state container assembled in `globals.js`; pe
 ```mermaid
 sequenceDiagram
     autonumber
-    participant Loop as p5.js draw loop
+    participant Frame as p5.js draw
     participant Timers as update_timers
     participant Combat as combat.fireWeapon
-    participant Game as game (shared state)
+    participant Game as game state
     participant Collision as update_collision
     participant Enemy
     participant Kill as helpers.processEnemyKill
 
-    Note over Loop,Timers: per-frame tick — auto-fire is timer-driven, not player-initiated
-    Loop->>Timers: shootTimer -= dt
+    Note over Frame,Timers: per-frame tick — auto-fire is timer-driven, not player-initiated
+    Frame->>Timers: shootTimer -= dt
     opt shootTimer <= 0
         Timers->>Combat: fireWeapon()
         Combat->>Game: read playerData talents / weapon tier
@@ -417,7 +418,7 @@ sequenceDiagram
         Combat->>Game: player.muzzleFlash = 4
     end
 
-    Loop->>Collision: updateBulletCollisions(g, dtF)
+    Frame->>Collision: updateBulletCollisions(g, dtF)
     Collision->>Game: move every bullet (b.x += b.vx * dtF)
     Collision->>Game: cull off-screen / over-range bullets
 


### PR DESCRIPTION
## Summary

Two follow-ups to PR #242 that surfaced after the merge:

### Mermaid parse error in §3.5 sequence diagram
GitHub's mermaid renderer fails on the diagram with \`Expecting 'ACTOR', got 'loop'\`. Cause: the participant identifier \`Loop\` collides with mermaid's \`loop\` block keyword case-insensitively, even when the participant is declared with capital L. Fix: rename the participant to \`Frame\`, also drop the word \"loop\" from its alias (\"p5.js draw loop\" -> \"p5.js draw\"), and strip parentheses from \"game (shared state)\" -> \"game state\" so the alias grammar is unambiguous.

### Missing ui.js in §3.2
\`docs/js/\` has 26 files but the table only listed 25; \`ui.js\` (pause menu, level select, lifecycle, skill / weapon-slot UI, revive and game-over overlays, debug overlay) was the missing row.

## Test plan
- [x] Diagram renders on GitHub without parse error (verified by reading raw mermaid against the lexer)
- [x] §3.2 row count now matches \`ls docs/js/ | wc -l\` (26)