### PR TITLE
fix: cheat panel sliders not draggable on touch devices

### DIFF
--- a/docs/js/input.js
+++ b/docs/js/input.js
@@ -95,16 +95,23 @@ function mouseMoved() {
     }
 }
 
-function touchMoved() {
+function _isTouchOnCanvas(e) {
+    const t = e && (e.target || (e.targetTouches && e.targetTouches[0] && e.targetTouches[0].target));
+    return !t || t.tagName === 'CANVAS';
+}
+
+function touchMoved(e) {
     if (game && game.state === 'playing' && touches.length > 0) {
         game.inputX = Math.max(-CONFIG.ROAD_HALF_WIDTH, Math.min(CONFIG.ROAD_HALF_WIDTH, _getWorldX(touches[0].x)));
     }
+    if (!_isTouchOnCanvas(e)) return;
     return false;
 }
 
-function touchStarted() {
+function touchStarted(e) {
     if (game && game.state === 'playing' && touches.length > 0) {
         game.inputX = Math.max(-CONFIG.ROAD_HALF_WIDTH, Math.min(CONFIG.ROAD_HALF_WIDTH, _getWorldX(touches[0].x)));
     }
+    if (!_isTouchOnCanvas(e)) return;
     return false;
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -6,7 +6,6 @@ html, body {
         radial-gradient(circle at top, #24385c 0%, #10182d 34%, #070b16 68%, #03050a 100%);
     overflow: hidden;
     font-family: 'Courier New', monospace;
-    touch-action: none;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     user-select: none;
@@ -51,6 +50,7 @@ body::after {
 #gameContainer canvas {
     display: block;
     width: 100%; height: 100%;
+    touch-action: none;
 }
 
 /* Overlay (Start / Game Over) */


### PR DESCRIPTION
## Summary
- Move `touch-action: none` from `html, body` to `#gameContainer canvas` so global gesture suppression no longer leaks into UI overlays
- Gate p5's `touchStarted` / `touchMoved` `return false` to canvas-targeted events only — touches on overlays no longer have their default action prevented
- Restores native drag behavior for `<input type="range">` sliders inside the modifier panel (and any other overlay UI) on touch devices

## Test plan
- [ ] On a touch device, open the modifier panel (triple-tap bottom-right hotspot or Ctrl+Shift+M) and confirm sliders in 玩家 / 装备 / 天赋 / 当前局 / 世界 tabs all drag smoothly
- [ ] Confirm in-game touch steering on the canvas still works (no scroll/zoom interference)
- [ ] Desktop mouse drag of the same sliders still works