### PR TITLE
fix: cheat panel sliders not draggable on desktop mouse

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Bridge Assault - 桥梁突击 (p5)</title>
 <link rel="icon" type="image/png" href="assets/favicon.png">
-<link rel="stylesheet" href="style.css?v=24">
+<link rel="stylesheet" href="style.css?v=25">
 <style>
 /* p5.js 1.11 wraps the default canvas in body > main. Keep that main
    canvas fixed behind overlays without touching level-select mini-canvases. */
@@ -314,31 +314,31 @@ body > canvas {
 </div>
 
 <!-- Game modules (order matters: dependencies first) -->
-<script src="js/crypto.js?v=58"></script>
-<script src="js/config.js?v=58"></script>
-<script src="js/i18n.js?v=58"></script>
-<script src="js/globals.js?v=58"></script>
-<script src="js/audio.js?v=58"></script>
-<script src="js/core.js?v=58"></script>
-<script src="js/helpers.js?v=58"></script>
-<script src="js/spawn.js?v=58"></script>
-<script src="js/combat.js?v=58"></script>
-<script src="js/draw.js?v=58"></script>
-<script src="js/hud.js?v=58"></script>
-<script src="js/update_timers.js?v=58"></script>
-<script src="js/update_collision.js?v=58"></script>
-<script src="js/update_enemies.js?v=58"></script>
-<script src="js/update_world.js?v=58"></script>
-<script src="js/update_effects.js?v=58"></script>
-<script src="js/update.js?v=58"></script>
-<script src="js/render.js?v=58"></script>
-<script src="js/achievements.js?v=58"></script>
-<script src="js/shop.js?v=58"></script>
-<script src="js/leaderboard.js?v=58"></script>
-<script src="js/input.js?v=58"></script>
-<script src="js/ui.js?v=58"></script>
-<script src="js/tutorial.js?v=58"></script>
-<script src="js/main.js?v=58"></script>
-<script src="js/cheat.js?v=58"></script>
+<script src="js/crypto.js?v=59"></script>
+<script src="js/config.js?v=59"></script>
+<script src="js/i18n.js?v=59"></script>
+<script src="js/globals.js?v=59"></script>
+<script src="js/audio.js?v=59"></script>
+<script src="js/core.js?v=59"></script>
+<script src="js/helpers.js?v=59"></script>
+<script src="js/spawn.js?v=59"></script>
+<script src="js/combat.js?v=59"></script>
+<script src="js/draw.js?v=59"></script>
+<script src="js/hud.js?v=59"></script>
+<script src="js/update_timers.js?v=59"></script>
+<script src="js/update_collision.js?v=59"></script>
+<script src="js/update_enemies.js?v=59"></script>
+<script src="js/update_world.js?v=59"></script>
+<script src="js/update_effects.js?v=59"></script>
+<script src="js/update.js?v=59"></script>
+<script src="js/render.js?v=59"></script>
+<script src="js/achievements.js?v=59"></script>
+<script src="js/shop.js?v=59"></script>
+<script src="js/leaderboard.js?v=59"></script>
+<script src="js/input.js?v=59"></script>
+<script src="js/ui.js?v=59"></script>
+<script src="js/tutorial.js?v=59"></script>
+<script src="js/main.js?v=59"></script>
+<script src="js/cheat.js?v=59"></script>
 </body>
 </html>

--- a/docs/js/input.js
+++ b/docs/js/input.js
@@ -95,6 +95,15 @@ function mouseMoved() {
     }
 }
 
+// p5.js 1.x falls back to touchStarted/touchMoved/touchEnded when the
+// matching mouse* handler is missing, then calls preventDefault() if the
+// touch handler returns false. That blocks every mousedown on UI overlays
+// (e.g. cheat panel sliders), so define explicit no-op mouse handlers to
+// short-circuit the fallback.
+function mousePressed() {}
+function mouseDragged() {}
+function mouseReleased() {}
+
 function _isTouchOnCanvas(e) {
     const t = e && (e.target || (e.targetTouches && e.targetTouches[0] && e.targetTouches[0].target));
     return !t || t.tagName === 'CANVAS';


### PR DESCRIPTION
## Summary
- p5.js 1.x falls back to `touchStarted` / `touchMoved` / `touchEnded` when the matching `mouse*` handler is missing, then calls `preventDefault()` if the touch handler returns `false`. Our touch handlers returned `false` unconditionally, so every mousedown on UI overlays — including modifier-panel sliders — was getting cancelled before the browser's native drag could start.
- Define explicit no-op `mousePressed` / `mouseDragged` / `mouseReleased` so p5 never falls through to the touch handlers for mouse events.
- Bump `style.css` and `js/*.js` cache-busting versions so clients pick up the fix without a hard refresh.

## Why the previous PR (#253) wasn't enough
PR #253 fixed the touch path (target-aware preventDefault + canvas-only `touch-action: none`) but didn't address p5's mouse→touch handler fallback. On desktop, mouse events were still going through `touchStarted` and getting `preventDefault`'d.

## Test plan
- [ ] Hard-refresh on desktop, open the modifier panel, confirm every slider in 玩家 / 装备 / 天赋 / 当前局 / 世界 tabs drags smoothly with mouse and updates its displayed value
- [ ] Verify in-game canvas mouse aiming (mouseMoved → game.inputX) still works
- [ ] Verify on a touch device that sliders still drag (regression check on PR #253 fix)